### PR TITLE
Shell controls

### DIFF
--- a/css/acorn-player.css
+++ b/css/acorn-player.css
@@ -228,59 +228,71 @@ h1, h2, h3, h4, h5, h6 {
 
 }
 
-#acorn-player > #controls > .control {
+#acorn-player > #controls > #acorn-controls > .control,
+#acorn-player > #controls > #shell-controls > .control {
   padding-top: 1px;
   padding-bottom: 1px;
   height: 28px;
 }
 
-#acorn-player > #controls > .control[disabled=disabled] {
+#acorn-player > #controls > #acorn-controls > .control[disabled=disabled],
+#acorn-player > #controls > #shell-controls > .control[disabled=disabled] {
   pointer-events: none;
   opacity: 0.3;
 }
 
-#acorn-player > #controls > .control:hover {
+#acorn-player > #controls > #acorn-controls > .control:hover,
+#acorn-player > #controls > #shell-controls > .control:hover {
   margin-top: 2px;
 }
 
-#acorn-player > #controls > .control:active {
+#acorn-player > #controls > #acorn-controls > .control:active,
+#acorn-player > #controls > #shell-controls > .control:active {
   margin-top: 4px;
 }
 
-#acorn-player > #controls > .control.right {
+#acorn-player > #controls > #acorn-controls {
+  float: right;
+}
+
+#acorn-player > #controls > #shell-controls {
+  float: left;
+}
+
+#acorn-player > #controls > #acorn-controls > .control {
   float: right;
   padding-right: 1px;
   border-left: 1px solid #ccc;
 }
 
-#acorn-player > #controls > .control.left {
+#acorn-player > #controls > #shell-controls > .control {
   float: left;
   padding-left: 1px;
   border-right: 1px solid #ccc;
 }
 
 
-#acorn-player > #controls > #acorn.control {
+#acorn-player > #controls > #acorn-controls > #acorn.control {
   background: no-repeat url("/img/controls/acorn.png") 0px -2px;
 }
 
-#acorn-player > #controls > #fullscreen.control {
+#acorn-player > #controls > #acorn-controls > #fullscreen.control {
   background: no-repeat url("/img/controls/acorn.png") -30px -2px;
 }
 
-#acorn-player > #controls > #edit.control {
+#acorn-player > #controls > #acorn-controls > #edit.control {
   background: no-repeat url("/img/controls/acorn.png") -90px -2px;
 }
 
-#acorn-player > #controls > #left.control {
+#acorn-player > #controls > #shell-controls > #left.control {
   background: no-repeat url("/img/controls/acorn.png") -150px -2px;
 }
 
-#acorn-player > #controls > #right.control {
+#acorn-player > #controls > #shell-controls > #right.control {
   background: no-repeat url("/img/controls/acorn.png") -120px -2px;
 }
 
-#acorn-player > #controls > #list.control {
+#acorn-player > #controls > #shell-controls > #list.control {
   background: no-repeat url("/img/controls/acorn.png") -180px -2px;
 }
 

--- a/css/acorn-player.css
+++ b/css/acorn-player.css
@@ -228,71 +228,59 @@ h1, h2, h3, h4, h5, h6 {
 
 }
 
-#acorn-player > #controls > #acorn-controls > .control,
-#acorn-player > #controls > #shell-controls > .control {
+#acorn-player > #controls > .control {
   padding-top: 1px;
   padding-bottom: 1px;
   height: 28px;
 }
 
-#acorn-player > #controls > #acorn-controls > .control[disabled=disabled],
-#acorn-player > #controls > #shell-controls > .control[disabled=disabled] {
+#acorn-player > #controls > .control[disabled=disabled] {
   pointer-events: none;
   opacity: 0.3;
 }
 
-#acorn-player > #controls > #acorn-controls > .control:hover,
-#acorn-player > #controls > #shell-controls > .control:hover {
+#acorn-player > #controls > .control:hover {
   margin-top: 2px;
 }
 
-#acorn-player > #controls > #acorn-controls > .control:active,
-#acorn-player > #controls > #shell-controls > .control:active {
+#acorn-player > #controls > .control:active {
   margin-top: 4px;
 }
 
-#acorn-player > #controls > #acorn-controls {
-  float: right;
-}
-
-#acorn-player > #controls > #shell-controls {
-  float: left;
-}
-
-#acorn-player > #controls > #acorn-controls > .control {
+#acorn-player > #controls > .control.right {
   float: right;
   padding-right: 1px;
   border-left: 1px solid #ccc;
 }
 
-#acorn-player > #controls > #shell-controls > .control {
+#acorn-player > #controls > .control.left {
   float: left;
   padding-left: 1px;
   border-right: 1px solid #ccc;
 }
 
 
-#acorn-player > #controls > #acorn-controls > #acorn.control {
+#acorn-player > #controls > #acorn.control {
   background: no-repeat url("/img/controls/acorn.png") 0px -2px;
 }
 
-#acorn-player > #controls > #acorn-controls > #fullscreen.control {
+#acorn-player > #controls > #fullscreen.control {
   background: no-repeat url("/img/controls/acorn.png") -30px -2px;
 }
 
-#acorn-player > #controls > #acorn-controls > #edit.control {
+#acorn-player > #controls > #edit.control {
   background: no-repeat url("/img/controls/acorn.png") -90px -2px;
 }
 
-#acorn-player > #controls > #shell-controls > #left.control {
+#acorn-player > #controls > #left.control {
   background: no-repeat url("/img/controls/acorn.png") -150px -2px;
 }
 
-#acorn-player > #controls > #shell-controls > #right.control {
+#acorn-player > #controls > #right.control {
   background: no-repeat url("/img/controls/acorn.png") -120px -2px;
 }
 
-#acorn-player > #controls > #shell-controls > #list.control {
+#acorn-player > #controls > #list.control {
   background: no-repeat url("/img/controls/acorn.png") -180px -2px;
 }
 

--- a/js/src/acorn.js
+++ b/js/src/acorn.js
@@ -434,7 +434,7 @@
     if (!isObject(obj)) return obj;
     return isArray(obj) ? obj.slice() : extend({}, obj);
   };
-  acorn.util.clone = clone;
+  acorn.util.clone;
 
 
   // Originally from backbone.js 0.9.1:

--- a/js/src/acorn.js
+++ b/js/src/acorn.js
@@ -434,7 +434,7 @@
     if (!isObject(obj)) return obj;
     return isArray(obj) ? obj.slice() : extend({}, obj);
   };
-  acorn.util.clone;
+  acorn.util.clone = clone;
 
 
   // Originally from backbone.js 0.9.1:

--- a/js/src/acorn.player.js
+++ b/js/src/acorn.player.js
@@ -99,7 +99,7 @@
     //
     // * show:content - fired when ContentView should be shown
     // * show:edit    - fired when EditView should be shown
-    // * close:edit   - fired when EditView shold be closed
+    // * close:edit   - fired when EditView should be closed
     //
     // * fullscreen   - fired when acorn should display in fullscreen
     // * acorn-site   - fired to go to the acorn website
@@ -107,6 +107,7 @@
     // * playback:play - fired when playback should start or resume
     // * playback:stop - fired when playback should pause or stop
     // * playback:ended - fired when playback has finished
+
 
 
 
@@ -162,7 +163,7 @@
     },
 
     render: function() {
-
+      
       this.$el.empty();
 
       if (this.options.autohideControls)
@@ -175,9 +176,22 @@
         this.contentView.render();
         this.controlsView.render();
 
+        // give shellView a handle to shellControls
+        this.setShellControls();
+
         this.$el.append(this.contentView.el);
         this.$el.append(this.controlsView.el);
       }
+    },
+
+    setShellControls: function() {
+      var shellView = this.contentView.shellView;
+      var shellControls = this.controlsView.shellControls;
+
+      assert(shellControls && shellView, 'ContentView and ControlsView must '+
+            'be rendered');
+
+      shellView.setControlsView(shellControls);
     },
 
     onAcornSave: function() {
@@ -254,7 +268,6 @@
     },
 
     onFullscreen: function() {
-      console.log('fullscreen triggered');
       var elem = this.$el[0];
       if (elem.requestFullscreen) {
         elem.requestFullscreen();
@@ -366,7 +379,10 @@
 
 
   // control views.
-  player.views.controls = {};
+  player.views.controls = {
+    acornControls: {},
+    shellControls: {},
+  };
 
 
   // ** player.views.ControlsView ** view with media control buttons
@@ -376,25 +392,39 @@
 
     id: 'controls',
 
-    controls: [
-      'FullscreenControl',
-      'AcornControl',
-      'EditControl',
-    ],
-
-    // Supported trigger events
-    // * change:acorn - fired when acorn data has changed
-
-    initialize: function() {
-      PlayerSubview.prototype.initialize.call(this);
-
-      this.player.on('change:acorn', this.onAcornChange);
-    },
-
     render: function() {
+
+      this.acornControls = new player.views.AcornControlsView({
+        player: this.player,
+      });
+      this.shellControls = new player.views.ShellControlsView({
+        player: this.player,
+      });
+
       this.$el.empty();
 
+      this.acornControls.render();
+      this.shellControls.render();
+
+      this.$el.append(this.acornControls.el);
+      this.$el.append(this.shellControls.el);
+
+    },
+
+  });
+
+
+  // ** player.views.ControlsSubview ** a subcomponent view for ControlsView
+  // -----------------------------------------------------------------------
+
+  player.views.ControlsSubview = PlayerSubview.extend({
+
+    render: function() {
       var self = this;
+
+      this.$el.empty();
+      this.constructControlViews();
+
       _(this.controlViews).each(function(control) {
         // `control.el` got removed from the DOM above: `this.$el.empty()`.
         // the `control` view's elements thus need to be re-delegated.
@@ -407,27 +437,72 @@
       });
     },
 
-    onAcornChange: function() {
-
-      var controls = this.controls;
-
-      if (this.player.shell && this.player.shell.controls)
-        controls = controls.concat(this.player.shell.controls);
-
+    constructControlViews: function() {
       var self = this;
-      this.controlViews = _(controls).chain()
-        .map(function (ctrl) { return player.views.controls[ctrl]; })
+
+      this.controls = this.controls || [];
+
+      this.controlViews = _(this.controls).chain()
+        .map(function (ctrl) { return self.controlsList[ctrl]; })
         .filter(function (cls) { return !!cls; })
         .map(function (cls) { return new cls({controls: self}); })
         .value();
-
-      this.render();
     },
+
+    // override with correct subset of player.views.controls
+    controlsList: {},
 
     controlWithId: function(id) {
       return _.find(this.controlViews, function (ctrlView) {
         return ctrlView.id == id;
       });
+    },
+
+  });
+
+
+  // ** player.views.AcornControlsView ** view with acorn control buttons
+  // --------------------------------------------------------------------
+
+  player.views.AcornControlsView = player.views.ControlsSubview.extend({
+
+    id: 'acorn-controls',
+
+    initialize: function() {
+      PlayerSubview.prototype.initialize.call(this);
+
+      // by default, show all acorn controls
+      this.controls = this.options.controls || _.keys(this.controlsList);
+    },
+
+    controlsList: player.views.controls.acornControls,
+
+  });
+
+
+  // ** player.views.ShellControlsView ** view with shell control buttons
+  // --------------------------------------------------------------------
+
+  player.views.ShellControlsView = player.views.ControlsSubview.extend({
+
+    id: 'shell-controls',
+
+    initialize: function() {
+      PlayerSubview.prototype.initialize.call(this);
+
+      // by default, show no shell controls
+      this.controls = this.options.controls || [];
+    },
+
+    controlsList: player.views.controls.shellControls,
+
+    setControls: function(controls) {
+      if (!_.isArray(controls)) {
+        controls = [];
+      };
+
+      this.controls = controls;
+      this.render();
     },
 
   });
@@ -469,14 +544,16 @@
 
   });
 
-  // ** player.views.controls.FullscreenControl ** onClick : fullscreen
-  // -----------------------------------------------------------------
 
-  player.views.controls.FullscreenControl = player.views.Control.extend({
+  // ** player.views.controls.acornControls.FullscreenControl **
+  //    onClick : fullscreen
+  // -----------------------------------------------------------
+
+  player.views.controls.acornControls.FullscreenControl =
+      player.views.Control.extend({
     tooltip: 'Fullscreen',
 
     id: 'fullscreen',
-    className: 'control right',
 
     onClick: function() {
       this.controls.player.trigger('fullscreen');
@@ -484,14 +561,15 @@
 
   });
 
-  // ** player.views.controls.AcornControl ** onClick : acorn website
-  // ---------------------------------------------------------------------
+  // ** player.views.controls.acornControls.AcornControl **
+  //    onClick : acorn website
+  // ------------------------------------------------------
 
-  player.views.controls.AcornControl = player.views.Control.extend({
+  player.views.controls.acornControls.AcornControl =
+      player.views.Control.extend({
     tooltip: 'Website',
 
     id: 'acorn',
-    className: 'control right',
 
     onClick: function() {
       this.controls.player.trigger('acorn-site');
@@ -499,14 +577,14 @@
 
   });
 
-  // ** player.views.controls.EditControl ** onClick : edit
-  // ---------------------------------------------------------------------
+  // ** player.views.controls.acornControls.EditControl ** onClick : edit
+  // --------------------------------------------------------------------
 
-  player.views.controls.EditControl = player.views.Control.extend({
+  player.views.controls.acornControls.EditControl =
+      player.views.Control.extend({
     tooltip: 'Edit',
 
     id: 'edit',
-    className: 'control right',
 
     onClick: function() {
       this.controls.player.trigger('show:edit');
@@ -514,14 +592,15 @@
 
   });
 
-  // ** player.views.controls.LeftControl ** onClick : previous link
-  // ---------------------------------------------------------------------
+  // ** player.views.controls.shellControls.LeftControl **
+  //    onClick : previous shell
+  // -----------------------------------------------------
 
-  player.views.controls.LeftControl = player.views.Control.extend({
+  player.views.controls.shellControls.LeftControl =
+      player.views.Control.extend({
     tooltip: 'Prev', // short as it doesn't fit for now :/
 
     id: 'left',
-    className: 'control left',
 
     onClick: function() {
       this.controls.player.trigger('controls:left');
@@ -529,14 +608,15 @@
 
   });
 
-  // ** player.views.controls.RightControl ** onClick : next link
-  // ---------------------------------------------------------------------
+  // ** player.views.controls.shellControls.RightControl **
+  //    onClick : next shell
+  // ------------------------------------------------------
 
-  player.views.controls.RightControl = player.views.Control.extend({
+  player.views.controls.shellControls.RightControl =
+      player.views.Control.extend({
     tooltip: 'Next',
 
     id: 'right',
-    className: 'control left',
 
     onClick: function() {
       this.controls.player.trigger('controls:right');
@@ -544,14 +624,15 @@
 
   });
 
-  // ** player.views.controls.ListControl ** onClick : list links
-  // ---------------------------------------------------------------------
+  // ** player.views.controls.shellControls.ListControl **
+  //    onClick : list shells
+  // -----------------------------------------------------
 
-  player.views.controls.ListControl = player.views.Control.extend({
+  player.views.controls.shellControls.ListControl =
+      player.views.Control.extend({
     tooltip: 'Playlist',
 
     id: 'list',
-    className: 'control left',
 
     onClick: function() {
       this.controls.player.trigger('controls:list');

--- a/js/src/shells/multi.shell.js
+++ b/js/src/shells/multi.shell.js
@@ -201,25 +201,6 @@ MultiShell.ContentView = Shell.ContentView.extend({
     this.trigger('change:subview');
   },
 
-  updateControls: function() {
-    if (!this.shellControls) {
-      return;
-    };
-
-    var left = this.shellControls.controlWithId('left');
-    var list = this.shellControls.controlWithId('list');
-    var right = this.shellControls.controlWithId('right');
-
-    left.$el.removeAttr('disabled');
-    right.$el.removeAttr('disabled');
-
-    if (this.currentView == _.first(this.shellViews))
-      left.$el.attr('disabled', 'disabled');
-
-    if (this.currentView == _.last(this.shellViews))
-      right.$el.attr('disabled', 'disabled');
-  },
-
   // **togglePlaylist** toggle a container with subview summaries
   togglePlaylist: function() {
     if (this.playlistView) {
@@ -244,12 +225,22 @@ MultiShell.ContentView = Shell.ContentView.extend({
 
   // -- MultiShell Events
 
-  onControlsLinked: function() {
-    this.updateControls();
-  },
-
   onChangedSubview: function() {
-    this.updateControls();
+    var contentView = this.parent;
+    var controlsView = contentView.player.controlsView;
+
+    var left = controlsView.controlWithId('left');
+    var list = controlsView.controlWithId('list');
+    var right = controlsView.controlWithId('right');
+
+    left.$el.removeAttr('disabled');
+    right.$el.removeAttr('disabled');
+
+    if (this.currentView == _.first(this.shellViews))
+      left.$el.attr('disabled', 'disabled');
+
+    if (this.currentView == _.last(this.shellViews))
+      right.$el.attr('disabled', 'disabled');
   },
 
   triggerPlaybackStop: function() {

--- a/js/src/shells/multi.shell.js
+++ b/js/src/shells/multi.shell.js
@@ -201,6 +201,25 @@ MultiShell.ContentView = Shell.ContentView.extend({
     this.trigger('change:subview');
   },
 
+  updateControls: function() {
+    if (!this.controlsView) {
+      return;
+    };
+
+    var left = this.controlsView.controlWithId('left');
+    var list = this.controlsView.controlWithId('list');
+    var right = this.controlsView.controlWithId('right');
+
+    left.$el.removeAttr('disabled');
+    right.$el.removeAttr('disabled');
+
+    if (this.currentView == _.first(this.shellViews))
+      left.$el.attr('disabled', 'disabled');
+
+    if (this.currentView == _.last(this.shellViews))
+      right.$el.attr('disabled', 'disabled');
+  },
+
   // **togglePlaylist** toggle a container with subview summaries
   togglePlaylist: function() {
     if (this.playlistView) {
@@ -225,22 +244,12 @@ MultiShell.ContentView = Shell.ContentView.extend({
 
   // -- MultiShell Events
 
+  onControlsSet: function() {
+    this.updateControls();
+  },
+
   onChangedSubview: function() {
-    var contentView = this.parent;
-    var controlsView = contentView.player.controlsView;
-
-    var left = controlsView.controlWithId('left');
-    var list = controlsView.controlWithId('list');
-    var right = controlsView.controlWithId('right');
-
-    left.$el.removeAttr('disabled');
-    right.$el.removeAttr('disabled');
-
-    if (this.currentView == _.first(this.shellViews))
-      left.$el.attr('disabled', 'disabled');
-
-    if (this.currentView == _.last(this.shellViews))
-      right.$el.attr('disabled', 'disabled');
+    this.updateControls();
   },
 
   triggerPlaybackStop: function() {

--- a/js/src/shells/multi.shell.js
+++ b/js/src/shells/multi.shell.js
@@ -201,6 +201,25 @@ MultiShell.ContentView = Shell.ContentView.extend({
     this.trigger('change:subview');
   },
 
+  updateControls: function() {
+    if (!this.shellControls) {
+      return;
+    };
+
+    var left = this.shellControls.controlWithId('left');
+    var list = this.shellControls.controlWithId('list');
+    var right = this.shellControls.controlWithId('right');
+
+    left.$el.removeAttr('disabled');
+    right.$el.removeAttr('disabled');
+
+    if (this.currentView == _.first(this.shellViews))
+      left.$el.attr('disabled', 'disabled');
+
+    if (this.currentView == _.last(this.shellViews))
+      right.$el.attr('disabled', 'disabled');
+  },
+
   // **togglePlaylist** toggle a container with subview summaries
   togglePlaylist: function() {
     if (this.playlistView) {
@@ -225,22 +244,12 @@ MultiShell.ContentView = Shell.ContentView.extend({
 
   // -- MultiShell Events
 
+  onControlsLinked: function() {
+    this.updateControls();
+  },
+
   onChangedSubview: function() {
-    var contentView = this.parent;
-    var controlsView = contentView.player.controlsView;
-
-    var left = controlsView.controlWithId('left');
-    var list = controlsView.controlWithId('list');
-    var right = controlsView.controlWithId('right');
-
-    left.$el.removeAttr('disabled');
-    right.$el.removeAttr('disabled');
-
-    if (this.currentView == _.first(this.shellViews))
-      left.$el.attr('disabled', 'disabled');
-
-    if (this.currentView == _.last(this.shellViews))
-      right.$el.attr('disabled', 'disabled');
+    this.updateControls();
   },
 
   triggerPlaybackStop: function() {

--- a/js/src/shells/shell.js
+++ b/js/src/shells/shell.js
@@ -176,7 +176,6 @@ Shell.ContentView = ShellView.extend({
   initialize: function() {
     ShellView.prototype.initialize.call(this);
 
-    this.parent.on('linked:content-controls', this.onControlsLinked);
     this.parent.on('playback:play', this.onPlaybackPlay);
     this.parent.on('playback:stop', this.onPlaybackStop);
   },
@@ -186,10 +185,6 @@ Shell.ContentView = ShellView.extend({
     this.parent.off('playback:stop', this.onPlaybackStop);
 
     ShellView.prototype.remove.call(this);
-  },
-
-  setShellControls: function(shellControls) {
-    this.shellControls = shellControls;
   },
 
   // aspect ratio. undefined if it doesn't matter.
@@ -205,7 +200,6 @@ Shell.ContentView = ShellView.extend({
   // events that all shells should have?
   // onLoseFocus: function () {},
   // onGainFocus: function () {},
-  onControlsLinked: function () {},
   onPlaybackPlay: function () {},
   onPlaybackStop: function () {},
 

--- a/js/src/shells/shell.js
+++ b/js/src/shells/shell.js
@@ -176,6 +176,8 @@ Shell.ContentView = ShellView.extend({
   initialize: function() {
     ShellView.prototype.initialize.call(this);
 
+    this.on('set:controls', this.onControlsSet);
+
     this.parent.on('playback:play', this.onPlaybackPlay);
     this.parent.on('playback:stop', this.onPlaybackStop);
   },
@@ -185,6 +187,15 @@ Shell.ContentView = ShellView.extend({
     this.parent.off('playback:stop', this.onPlaybackStop);
 
     ShellView.prototype.remove.call(this);
+  },
+
+  setControlsView: function(controlsView) {
+    var controls = acorn.util.clone(this.shell.controls);
+
+    this.controlsView = controlsView;
+    controlsView.setControls(controls);
+
+    this.trigger('set:controls');
   },
 
   // aspect ratio. undefined if it doesn't matter.
@@ -200,6 +211,7 @@ Shell.ContentView = ShellView.extend({
   // events that all shells should have?
   // onLoseFocus: function () {},
   // onGainFocus: function () {},
+  onControlsSet: function () {},
   onPlaybackPlay: function () {},
   onPlaybackStop: function () {},
 

--- a/js/src/shells/shell.js
+++ b/js/src/shells/shell.js
@@ -176,6 +176,7 @@ Shell.ContentView = ShellView.extend({
   initialize: function() {
     ShellView.prototype.initialize.call(this);
 
+    this.parent.on('linked:content-controls', this.onControlsLinked);
     this.parent.on('playback:play', this.onPlaybackPlay);
     this.parent.on('playback:stop', this.onPlaybackStop);
   },
@@ -185,6 +186,10 @@ Shell.ContentView = ShellView.extend({
     this.parent.off('playback:stop', this.onPlaybackStop);
 
     ShellView.prototype.remove.call(this);
+  },
+
+  setShellControls: function(shellControls) {
+    this.shellControls = shellControls;
   },
 
   // aspect ratio. undefined if it doesn't matter.
@@ -200,6 +205,7 @@ Shell.ContentView = ShellView.extend({
   // events that all shells should have?
   // onLoseFocus: function () {},
   // onGainFocus: function () {},
+  onControlsLinked: function () {},
   onPlaybackPlay: function () {},
   onPlaybackStop: function () {},
 


### PR DESCRIPTION
- Subdivide controls into acorn controls and shell controls.
- Give the contentView in a shell easy access to it's shell controls and vice versa
- Streamline the rendering process of player subviews to ensure that contentView and controlsView thread properly

Closes issues #11, #12, #13.
