### PR TITLE
Empty inheritance

### DIFF
--- a/js/src/acorn.js
+++ b/js/src/acorn.js
@@ -104,12 +104,13 @@
 
   // canonical types of media
 
+  acorn.types.empty = true;
+  acorn.types.link = true;
   acorn.types.text = true;
   acorn.types.image = true;
   acorn.types.video = true;
   acorn.types.audio = true;
   acorn.types.document = true;
-  acorn.types.link = true;
   acorn.types.interactive = true;
   acorn.types.multimedia = true; // group of other types.
 

--- a/js/src/shells/empty.shell.js
+++ b/js/src/shells/empty.shell.js
@@ -6,7 +6,7 @@ var EmptyShell = acorn.shells.EmptyShell = LinkShell.extend({
   shellid: 'acorn.EmptyShell',
 
   // The canonical type of this media. One of `acorn.types`.
-  type: 'link', // TODO: type: 'empty'? something else?
+  type: 'empty',
 
   // valid if link is empty
   isValidLink: function(link) {

--- a/js/src/shells/empty.shell.js
+++ b/js/src/shells/empty.shell.js
@@ -1,5 +1,8 @@
-// EmptyShell --  A shell that handles an empty link.
-// ----------------------------------------------------------------
+// EmptyShell --  A shell that handles an empty acorn.
+// ---------------------------------------------------
+//
+// * TODO: remove EmptyShell from LinkShell inheritance chain. For this to
+//   happen, EditViews need to be refactored to accept non-LinkShells.
 
 var EmptyShell = acorn.shells.EmptyShell = LinkShell.extend({
 
@@ -21,7 +24,7 @@ var EmptyShell = acorn.shells.EmptyShell = LinkShell.extend({
 // Shell.ContentView -- informs viewers that this acorn is currently empty
 // -----------------------------------------------------------------------
 
-EmptyShell.ContentView =  LinkShell.ContentView.extend({
+EmptyShell.ContentView =  Shell.ContentView.extend({
 
   emptyMessage: function () {
     var messageText = 'this acorn is currently empty';


### PR DESCRIPTION
Refactoring EmptyShell to be outside of LinkShell's inheritance chain
