### PR TITLE
Edit views

### DIFF
--- a/css/acorn-player.css
+++ b/css/acorn-player.css
@@ -410,7 +410,12 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 #acorn-player > #edit > .content > #form .acorn-shell-edit > div >
-    div.thumbnailside > input#link {
+    div.thumbnailside #link-field {
+  margin-bottom: 9px;
+}
+
+#acorn-player > #edit > .content > #form .acorn-shell-edit > div >
+    div.thumbnailside input#link {
   width: 270px;
   float: left;
   margin-right: 5px;
@@ -431,11 +436,38 @@ h1, h2, h3, h4, h5, h6 {
   margin-top: 5px;
 }
 
+#acorn-player > #edit > .content > #form .acorn-shell-edit > div >
+    div.thumbnailside #slider-block {
+  position: relative;
+}
 
 #acorn-player > #edit > .content > #form .acorn-shell-edit > div >
     div.thumbnailside #slider {
-  margin-top: 10px;
-  margin-bottom: 10px;
+  margin: 10px 7px 10px 0px;
+  width: 355px;
+}
+
+#acorn-player > #edit > .content > #form .acorn-shell-edit > div >
+    div.thumbnailside #time {
+  position: absolute;
+  left: 365px;
+  top: -6px;
+  width: 46px;
+  height: 18px;
+  padding: 3px 5px;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  border-radius: 3px;
+  text-shadow: 0 1px 0 white;
+  text-align: center;
+  vertical-align: middle;
+  background-color: #EEE;
+  border: 1px solid #CCC;
+}
+
+#acorn-player > #edit > .content > #form .acorn-shell-edit > div >
+    div.thumbnailside .input-prepend:first-child .add-on {
+  margin-left: 0px;
 }
 
 #acorn-player .ui-slider-handle {

--- a/css/acorn-player.css
+++ b/css/acorn-player.css
@@ -410,10 +410,10 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 #acorn-player > #edit > .content > #form .acorn-shell-edit > div >
-    div.thumbnailside > div#link {
-  width: 350px;
+    div.thumbnailside > input#link {
+  width: 345px;
   float: left;
-  margin-right: 15px;
+  margin-right: 10px;
 }
 
 #acorn-player > #edit > .content > #form .acorn-shell-edit > div >

--- a/css/acorn-player.css
+++ b/css/acorn-player.css
@@ -429,6 +429,24 @@ h1, h2, h3, h4, h5, h6 {
   text-align: center;
 }
 
+#acorn-player > #edit .acorn-shell-edit .thumbnailside div.loop.hidden {
+  display: none;
+}
+
+#acorn-player > #edit .acorn-shell-edit .thumbnailside div.loop-none span,
+#acorn-player > #edit .acorn-shell-edit .thumbnailside div.loop-infinity span,
+#acorn-player > #edit .acorn-shell-edit .thumbnailside div.loop-n input {
+  width: 30px;
+  margin-left: -4px;
+  margin-right: 5px;
+  text-align: center;
+}
+
+#acorn-player > #edit .acorn-shell-edit .thumbnailside div.loop-none span,
+#acorn-player > #edit .acorn-shell-edit .thumbnailside div.loop-infinity span {
+  background-color: #F4F4F4;
+}
+
 #acorn-player > #edit > .content > #form .acorn-shell-edit > div >
     div.thumbnailside.right {
   position: absolute;

--- a/css/acorn-player.css
+++ b/css/acorn-player.css
@@ -321,13 +321,12 @@ h1, h2, h3, h4, h5, h6 {
   bottom: 20px;
   left: 20px;
   right: 20px;
-  overflow: scroll;
   z-index: 40;
 }
 
 #acorn-player > #edit > .content > #toolbar {
   position: relative;
-  width: 100%;
+  width: 558px;
   height: 40px;
   padding-bottom: 5px;
   border-bottom: 1px solid #ccc;
@@ -362,7 +361,8 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 #acorn-player > #edit > .content > #form {
-  overflow: scroll;
+  overflow-y: scroll;
+  overflow-x: hidden;
   margin-top: 56px;
   padding: 10px;
 }
@@ -381,6 +381,10 @@ h1, h2, h3, h4, h5, h6 {
 #acorn-player > #edit > .content > #form .acorn-shell-edit.selected,
 #acorn-player > #content .acorn-shell-summary.selected {
   background-color: #dff0d8;
+}
+
+#acorn-player > #edit > .content > #form > .acorn-shell-edit {
+  width: 538px;
 }
 
 #acorn-player > #edit > .content > #form .acorn-shell-edit > div {
@@ -409,16 +413,36 @@ h1, h2, h3, h4, h5, h6 {
   height: 80px;
 }
 
+#acorn-player > #edit > .content > #form .acorn-shell-edit > div
+    div.thumbnailside {
+  width: 423px;
+}
+
 #acorn-player > #edit > .content > #form .acorn-shell-edit > div >
     div.thumbnailside #link-field {
+  height: 28px;
   margin-bottom: 9px;
 }
 
 #acorn-player > #edit > .content > #form .acorn-shell-edit > div >
     div.thumbnailside input#link {
-  width: 270px;
-  float: left;
-  margin-right: 5px;
+  position: absolute;
+  width: 269px;
+  right: 144px;
+}
+
+#acorn-player > #edit > .content > #form .acorn-shell-edit > div >
+    div.thumbnailside button#delete {
+  position: absolute;
+  width: 58px;
+  right: 81px;
+}
+
+#acorn-player > #edit > .content > #form .acorn-shell-edit > div >
+    div.thumbnailside button#duplicate {
+  position: absolute;
+  width: 76px;
+  right: 0px;
 }
 
 #acorn-player > #edit > .content > #form .acorn-shell-edit > div >
@@ -498,11 +522,10 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 #acorn-player > #edit > .content > #form > .acorn-shell-edit > button#add {
-  margin-left: 120px;
-  margin-top: 10px;
-  margin-bottom: 30px;
+  display: block;
+  margin: 10px auto 30px;
   padding: 5px;
-  width: 420px;
+  width: 378px;
 }
 
 /* jquery ui hacks to match boostrap */

--- a/css/acorn-player.css
+++ b/css/acorn-player.css
@@ -411,9 +411,9 @@ h1, h2, h3, h4, h5, h6 {
 
 #acorn-player > #edit > .content > #form .acorn-shell-edit > div >
     div.thumbnailside > input#link {
-  width: 345px;
+  width: 270px;
   float: left;
-  margin-right: 10px;
+  margin-right: 5px;
 }
 
 #acorn-player > #edit > .content > #form .acorn-shell-edit > div >

--- a/css/acorn-player.css
+++ b/css/acorn-player.css
@@ -406,13 +406,14 @@ h1, h2, h3, h4, h5, h6 {
   left: 100px;
 
   margin-left: 15px;
-  margin-right: 10px;
   height: 80px;
 }
 
 #acorn-player > #edit > .content > #form .acorn-shell-edit > div >
     div.thumbnailside > div#link {
-  width: 100%;
+  width: 350px;
+  float: left;
+  margin-right: 15px;
 }
 
 #acorn-player > #edit > .content > #form .acorn-shell-edit > div >

--- a/css/acorn-player.css
+++ b/css/acorn-player.css
@@ -484,6 +484,11 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 #acorn-player > #edit > .content > #form .acorn-shell-edit > div >
+    div.thumbnailside > form > .control-group.time {
+  display: inline-block;
+}
+
+#acorn-player > #edit > .content > #form .acorn-shell-edit > div >
     div.thumbnailside .input-prepend:first-child .add-on {
   margin-left: 0px;
 }

--- a/js/src/acorn.js
+++ b/js/src/acorn.js
@@ -299,22 +299,25 @@
 
   // **acorn.secondsToTimeString** converts seconds to human-readable timeString
   // human-readable format is: [[hh:]mm:]ss[.SSS]
-  var secondsToTimeString = function(seconds) {
+  // format param may force placeholder zeroes in minutes or hours and minutes
+  var secondsToTimeString = function(seconds, format) {
     var timeString = '';
+
+    _.isObject(format) || (format = {});
 
     // get integer seconds
     var sec = parseInt(seconds, 10);
 
     // add hours part
     var hrs = parseInt(sec / (60 * 60), 10);
-    if (hrs) {
+    if (hrs || format.forceHours) {
       sec -= hrs * 60 * 60;
       timeString += hrs + ':';
     };
 
     // add minutes part
     var min = parseInt(sec / 60, 10);
-    if (hrs || min) {
+    if (hrs || format.forceHours || min || format.forceMinutes) {
       sec -= min * 60;
       min = (min < 10) ? '0' + min : min;
       timeString += min + ':';

--- a/js/src/acorn.js
+++ b/js/src/acorn.js
@@ -310,14 +310,14 @@
 
     // add hours part
     var hrs = parseInt(sec / (60 * 60), 10);
-    if (hrs || format.forceHours) {
+    if (hrs !== 0 || format.forceHours) {
       sec -= hrs * 60 * 60;
       timeString += hrs + ':';
     };
 
     // add minutes part
     var min = parseInt(sec / 60, 10);
-    if (hrs || format.forceHours || min || format.forceMinutes) {
+    if (hrs !== 0 || format.forceHours || min !== 0 || format.forceMinutes) {
       sec -= min * 60;
       min = (min < 10) ? '0' + min : min;
       timeString += min + ':';

--- a/js/src/shells/link.shell.js
+++ b/js/src/shells/link.shell.js
@@ -308,17 +308,10 @@ LinkShell.EditView = Shell.EditView.extend({
   onSaveLink: function() {
     var value = this.$('input#link').val();
 
-    // reset to previous value if field is empty
-    if (value === '') {
-      this.$('input#link').val(this.link());
+    if (this.validateLink(value))
+      console.log('invalid link');
 
-    // else validate and save
-    } else {
-      if (this.validateLink(value))
-        console.log('invalid link');
-
-      this.link(value);
-    };
+    this.link(value);
   },
 
   onDeleteShell: function() {

--- a/js/src/shells/link.shell.js
+++ b/js/src/shells/link.shell.js
@@ -190,6 +190,7 @@ LinkShell.EditView = Shell.EditView.extend({
     'blur input#link': 'onBlurLinkField',
     'keyup input#link': 'onKeyupLinkField',
     'click button#delete': 'onClickDelete',
+    'click button#duplicate': 'onClickDuplicate',
     'click button#add': 'onClickAdd',
   },
 
@@ -199,6 +200,7 @@ LinkShell.EditView = Shell.EditView.extend({
       <div class="thumbnailside">\
         <input type="text" id="link" placeholder="Enter Link" />\
         <button class="btn" id="delete">delete</button>\
+        <button class="btn" id="duplicate">duplicate</button>\
       </div>\
     </div>\
     <button class="btn btn-large" id="add">Add Link</button>\
@@ -325,6 +327,10 @@ LinkShell.EditView = Shell.EditView.extend({
 
   onClickDelete: function() {
     this.trigger('delete:shell', this);
+  },
+
+  onClickDuplicate: function() {
+    this.trigger('duplicate:shell', this);
   },
 
   // **onClickAdd** add another link

--- a/js/src/shells/link.shell.js
+++ b/js/src/shells/link.shell.js
@@ -227,11 +227,11 @@ LinkShell.EditView = Shell.EditView.extend({
 
       // if the shellid has changed, we need to swap shells entirely.
       if (s.shellid != this.shell.data.shell)
-        this.trigger('swap:shell', s.data);
+        this.trigger('swap:shell', s.data, this);
 
       // else, announce that the shell has changed.
       else
-        this.trigger('change:shell', this.shell);
+        this.trigger('change:shell', this.shell, this);
     }
     return this.shell.link();
   },
@@ -324,7 +324,7 @@ LinkShell.EditView = Shell.EditView.extend({
   },
 
   onClickDelete: function() {
-    this.trigger('delete:shell');
+    this.trigger('delete:shell', this);
   },
 
   // **onClickAdd** add another link
@@ -334,7 +334,7 @@ LinkShell.EditView = Shell.EditView.extend({
     var multiShell = new acorn.shells.MultiShell();
     multiShell.addShell(this.shell);
     multiShell.addShell(new acorn.shellForLink(''));
-    this.trigger('swap:shell', multiShell.data);
+    this.trigger('swap:shell', multiShell.data, this);
   },
 
 

--- a/js/src/shells/link.shell.js
+++ b/js/src/shells/link.shell.js
@@ -187,6 +187,7 @@ LinkShell.ContentView = Shell.ContentView.extend({
 LinkShell.EditView = Shell.EditView.extend({
 
   events: {
+    'click button#delete': 'onClickDelete',
     'click button#add': 'onClickAdd',
   },
 
@@ -195,6 +196,7 @@ LinkShell.EditView = Shell.EditView.extend({
       <img id="thumbnail" />\
       <div class="thumbnailside">\
         <div id="link"></div>\
+        <button class="btn" id="delete">delete</button>\
       </div>\
     </div>\
     <button class="btn btn-large" id="add">Add Link</button>\
@@ -208,11 +210,9 @@ LinkShell.EditView = Shell.EditView.extend({
       placeholder: 'Enter Link',
       validate: _.bind(this.validateLink, this),
       addToggle: true,
-      deleteFn: _.bind(this.triggerDelete, this),
     });
 
     this.on('delete:shell', this.onDeleteShell);
-
   },
 
   validateLink: function(link) {
@@ -257,7 +257,7 @@ LinkShell.EditView = Shell.EditView.extend({
       this.$el.find('button#add').hide();
   },
 
-  triggerDelete: function() {
+  onClickDelete: function() {
     this.trigger('delete:shell');
   },
 

--- a/js/src/shells/link.shell.js
+++ b/js/src/shells/link.shell.js
@@ -198,9 +198,11 @@ LinkShell.EditView = Shell.EditView.extend({
     <div>\
       <img id="thumbnail" />\
       <div class="thumbnailside">\
-        <input type="text" id="link" placeholder="Enter Link" />\
-        <button class="btn" id="delete">delete</button>\
-        <button class="btn" id="duplicate">duplicate</button>\
+        <div id="link-field">\
+          <input type="text" id="link" placeholder="Enter Link" />\
+          <button class="btn" id="delete">delete</button>\
+          <button class="btn" id="duplicate">duplicate</button>\
+        </div>\
       </div>\
     </div>\
     <button class="btn btn-large" id="add">Add Link</button>\

--- a/js/src/shells/link.shell.js
+++ b/js/src/shells/link.shell.js
@@ -250,16 +250,6 @@ LinkShell.EditView = Shell.EditView.extend({
       this.$el.find('button#add').hide();
   },
 
-  onClickDelete: function() {
-    this.trigger('delete:shell');
-  },
-
-  onDeleteShell: function() {
-    if (!this.isSubShellView()) {
-      this.link('');
-    };
-  },
-
   generateThumbnailLink: function(callback) {
     callback = callback || function() {};
 
@@ -325,6 +315,16 @@ LinkShell.EditView = Shell.EditView.extend({
 
       this.link(value);
     };
+  },
+
+  onDeleteShell: function() {
+    if (!this.isSubShellView()) {
+      this.link('');
+    };
+  },
+
+  onClickDelete: function() {
+    this.trigger('delete:shell');
   },
 
   // **onClickAdd** add another link

--- a/js/src/shells/multi.shell.js
+++ b/js/src/shells/multi.shell.js
@@ -454,18 +454,9 @@ MultiShell.EditView = Shell.EditView.extend({
     });
 
     // listen to events of shell EditView
-    shellView.on('swap:shell', function(data) {
-      this.onSwapSubShell(data, shellView);
-    }, this);
-
-    shellView.on('change:shell', function(data) {
-      this.onChangeSubShell(data, shellView);
-    }, this);
-
-    shellView.on('delete:shell', function() {
-      this.onDeleteSubShell(shellView);
-    }, this);
-
+    shellView.on('swap:shell', this.onSwapSubShell);
+    shellView.on('change:shell', this.onChangeSubShell);
+    shellView.on('delete:shell', this.onDeleteSubShell);
     shellView.on('change:editState', this.onChangeEditState);
 
     return shellView;
@@ -569,11 +560,11 @@ MultiShell.EditView = Shell.EditView.extend({
 
       // if there is at most 1 shell, swap.
       if (shells.length <= 1)
-        this.trigger('swap:shell', shells[0] || {});
+        this.trigger('swap:shell', shells[0] || {}, this);
 
       // else, announce that the shell has changed.
       else
-        this.trigger('change:shell', this.shell);
+        this.trigger('change:shell', this.shell, this);
     }
     return this.shell.data.shells;
   },

--- a/js/src/shells/multi.shell.js
+++ b/js/src/shells/multi.shell.js
@@ -457,6 +457,7 @@ MultiShell.EditView = Shell.EditView.extend({
     shellView.on('swap:shell', this.onSwapSubShell);
     shellView.on('change:shell', this.onChangeSubShell);
     shellView.on('delete:shell', this.onDeleteSubShell);
+    shellView.on('duplicate:shell', this.onDuplicateSubShell);
     shellView.on('change:editState', this.onChangeEditState);
 
     return shellView;
@@ -551,6 +552,32 @@ MultiShell.EditView = Shell.EditView.extend({
 
     // remove shellview
     shellView.remove();
+  },
+
+  onDuplicateSubShell: function(shellView) {
+    var index, shellData, shells, duplicateShellView;
+
+    // get next index and duplicate data
+    index = this.indexOfView(shellView) + 1;
+    shellData = this.duplicateShellData(shellView.shell.data);
+
+    // add duplicate to `this.shells`
+    shells = this.shells();
+    shells.splice(index, 0, shellData);
+    this.shells(shells);
+
+    // add duplicate to `this.shellViews`
+    duplicateShellView = this.constructView(shellData);
+    this.shellViews.splice(index, 0, duplicateShellView);
+
+    // add duplicate to DOM
+    duplicateShellView.render();
+    shellView.$el.after(duplicateShellView.el);
+  },
+
+  duplicateShellData: function(data) {
+    // for now, all data is shallow and a simple clone is sufficient
+    return _.clone(data);
   },
 
   // get/setter for shells value

--- a/js/src/shells/videolink.shell.js
+++ b/js/src/shells/videolink.shell.js
@@ -174,7 +174,10 @@ VideoLinkShell.EditView = LinkShell.EditView.extend({
   }),
 
   timeRangeTemplate: _.template('\
-  <div id="slider" class="fader"></div>\
+  <div id="slider-block">\
+    <div id="slider" class="fader"></div>\
+    <div id="time"></div>\
+  </div>\
   <form class="form-inline">\
     <div class="input-prepend">\
       <span class="add-on">start:</span>\
@@ -186,7 +189,6 @@ VideoLinkShell.EditView = LinkShell.EditView.extend({
       <input id="end" size="16" type="text" class="time">\
       <!--<span class="add-on">sec</span>-->\
     </div>\
-    total time: <span id="time"></span>\
     <label class="checkbox right" id="loop-label">\
       <input id="loop" type="checkbox"> Loop\
     </label>\

--- a/js/src/shells/videolink.shell.js
+++ b/js/src/shells/videolink.shell.js
@@ -263,14 +263,14 @@ VideoLinkShell.EditView = LinkShell.EditView.extend({
     var loop = !!this.$el.find('#loop').attr('checked');
 
     var diff = (end - start);
-    var time = (isNaN(diff) ? '--' : secondsToTimeString(diff));
+    var time = (isNaN(diff) ? '--' : secondsToTimeString(diff, {forceMinutes: true}));
 
     this.shell.data.time_start = start;
     this.shell.data.time_end = end;
     this.shell.data.loop = loop;
 
-    this.$el.find('#start').val(secondsToTimeString(start));
-    this.$el.find('#end').val(secondsToTimeString(end));
+    this.$el.find('#start').val(secondsToTimeString(start, {forceMinutes: true}));
+    this.$el.find('#end').val(secondsToTimeString(end, {forceMinutes: true}));
     this.$el.find('#time').text(time);
     this.$el.find('#slider').slider({ max: max, values: [start, end] });
   },

--- a/js/src/shells/videolink.shell.js
+++ b/js/src/shells/videolink.shell.js
@@ -167,8 +167,10 @@ VideoLinkShell.ContentView = LinkShell.ContentView.extend({
 VideoLinkShell.EditView = LinkShell.EditView.extend({
 
   events: _.extend({}, LinkShell.EditView.prototype.events, {
-    'change input':  'timeInputChanged',
-    'blur input':  'timeInputChanged',
+    'change input.time':  'timeInputChanged',
+    'blur input.time':  'timeInputChanged',
+    'change input#loop':  'timeInputChanged',
+    'blur input#loop':  'timeInputChanged',
   }),
 
   timeRangeTemplate: _.template('\

--- a/js/src/shells/videolink.shell.js
+++ b/js/src/shells/videolink.shell.js
@@ -289,6 +289,12 @@ VideoLinkShell.EditView = LinkShell.EditView.extend({
     this.trigger('change:shell', this.shell, this);
   },
 
+  // Args, contained in a single object:
+  // @number start - current start time in seconds
+  // @number end - current end time in seconds
+  // @string [lock] - name the time nob ('start' or 'end') to lock down if the
+  //     times are incompatible (e.g. start = 46, end = 12). by default, start
+  //     will be locked
   inputChanged: function(params) {
     var offset, max, bound, floatOrDefault, start, end, timeControls, diff,
         time;

--- a/js/src/shells/videolink.shell.js
+++ b/js/src/shells/videolink.shell.js
@@ -229,7 +229,7 @@ VideoLinkShell.EditView = LinkShell.EditView.extend({
         self.inputChanged(ui.values);
       },
       stop: function(e, ui) {
-        self.trigger('change:shell', self.shell);
+        self.trigger('change:shell', self.shell, self);
       },
     });
 
@@ -242,7 +242,7 @@ VideoLinkShell.EditView = LinkShell.EditView.extend({
       timeStringToSeconds(this.$el.find('#start').val()),
       timeStringToSeconds(this.$el.find('#end').val())
     ]);
-    this.trigger('change:shell', this.shell);
+    this.trigger('change:shell', this.shell, this);
   },
 
   inputChanged: function(values) {


### PR DESCRIPTION
Redesign shell edit views, including:
- duplicating shells
- replacing editable text components with save-on-blur input fields
- fixed-width content
- new video edit view design for looping and total-time

![](http://static.benet.ai/skitch_tenedor/acorn_-_multimedia_wrapper-20121118-124742.jpg)
