### PR TITLE
Slider

### DIFF
--- a/css/acorn-player.css
+++ b/css/acorn-player.css
@@ -522,8 +522,14 @@ h1, h2, h3, h4, h5, h6 {
   margin-left: 0px;
 }
 
+#acorn-player .ui-range-slider {
+  height: 12px;
+}
+
 #acorn-player .ui-range-slider .ui-slider-handle {
-  width: 0.8em;
+  width: 12px;
+  height: 18px;
+  top: -4px;
   margin-left: -1px;
 }
 

--- a/css/acorn-player.css
+++ b/css/acorn-player.css
@@ -524,7 +524,7 @@ h1, h2, h3, h4, h5, h6 {
 
 #acorn-player .ui-slider-handle {
   width: 0.8em;
-  margin-left: 0px;
+  margin-left: -1px;
 }
 
 #acorn-player > #edit > .content > #form > .acorn-shell-edit > button#add {

--- a/css/acorn-player.css
+++ b/css/acorn-player.css
@@ -524,6 +524,7 @@ h1, h2, h3, h4, h5, h6 {
 
 #acorn-player .ui-slider-handle {
   width: 0.8em;
+  margin-left: 0px;
 }
 
 #acorn-player > #edit > .content > #form > .acorn-shell-edit > button#add {

--- a/css/acorn-player.css
+++ b/css/acorn-player.css
@@ -489,7 +489,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 #acorn-player > #edit > .content > #form .acorn-shell-edit > div >
-    div.thumbnailside #slider {
+    div.thumbnailside .ui-range-slider {
   margin: 10px 7px 10px 0px;
   width: 355px;
 }
@@ -522,7 +522,7 @@ h1, h2, h3, h4, h5, h6 {
   margin-left: 0px;
 }
 
-#acorn-player .ui-slider-handle {
+#acorn-player .ui-range-slider .ui-slider-handle {
   width: 0.8em;
   margin-left: -1px;
 }
@@ -555,7 +555,7 @@ h1, h2, h3, h4, h5, h6 {
 
 }
 
-.ui-slider .ui-slider-range {
+.ui-range-slider .ui-slider-range {
   background-color: #414141;
   *background-color: #222222;
   background-image: -ms-linear-gradient(top, #555555, #222222);

--- a/js/src/shells/videolink.shell.js
+++ b/js/src/shells/videolink.shell.js
@@ -284,11 +284,12 @@ VideoLinkShell.EditView = LinkShell.EditView.extend({
   },
 
   timeInputChanged: function(changed) {
-    this.inputChanged({
+    var data = {
       start: timeStringToSeconds(this.$el.find('#start').val()),
       end: timeStringToSeconds(this.$el.find('#end').val()),
-      lock: changed,
-    });
+    };
+
+    this.inputChanged(data, {lock: changed});
 
     this.trigger('change:shell', this.shell, this);
   },
@@ -299,7 +300,7 @@ VideoLinkShell.EditView = LinkShell.EditView.extend({
   // @string [lock] - name the time nob ('start' or 'end') to lock down if the
   //     times are incompatible (e.g. start = 46, end = 19). by default, start
   //     will be locked
-  inputChanged: function(params) {
+  inputChanged: function(data, options) {
     var offset, max, bound, floatOrDefault, start, end, timeControls, diff,
         time;
 
@@ -314,15 +315,15 @@ VideoLinkShell.EditView = LinkShell.EditView.extend({
       return (_.isNumber(num) && !_.isNaN(num)) ? parseFloat(num) : def;
     };
 
-    start = floatOrDefault(params.start, 0);
-    end = floatOrDefault(params.end, max);
+    start = floatOrDefault(data.start, 0);
+    end = floatOrDefault(data.end, max);
 
     start = bound(start);
     end = bound(end);
 
     // prohibit negative length
     if (end < start) {
-      if (params.lock === 'end')
+      if (options.lock === 'end')
         start = bound(end - offset);
       else
         end = bound(start + offset);

--- a/js/src/shells/videolink.shell.js
+++ b/js/src/shells/videolink.shell.js
@@ -239,7 +239,6 @@ VideoLinkShell.EditView = LinkShell.EditView.extend({
 
     // setup slider
     self = this;
-    this.$el.find('#slider').slider('destroy');
     this.$el.find('#slider').slider({
       min: 0,
       max: max,

--- a/js/src/shells/videolink.shell.js
+++ b/js/src/shells/videolink.shell.js
@@ -289,7 +289,7 @@ VideoLinkShell.EditView = LinkShell.EditView.extend({
       end: timeStringToSeconds(this.$el.find('#end').val()),
     };
 
-    this.inputChanged(data, {lock: changed});
+    this.inputChanged(data, {lock: changed, updateSlider: true});
 
     this.trigger('change:shell', this.shell, this);
   },
@@ -301,9 +301,10 @@ VideoLinkShell.EditView = LinkShell.EditView.extend({
   //     times are incompatible (e.g. start = 46, end = 19). by default, start
   //     will be locked
   inputChanged: function(data, options) {
-    var offset, max, bound, floatOrDefault, start, end, timeControls, diff,
+    var offset, max, bound, floatOrDefault, start, end, invalidTimes, diff,
         time;
 
+    _.isObject(options) || (options = {});
     offset = 10;
     max = this.shell.data.time_total || this.shell.duration();
 
@@ -322,7 +323,9 @@ VideoLinkShell.EditView = LinkShell.EditView.extend({
     end = bound(end);
 
     // prohibit negative length
-    if (end < start) {
+    invalidTimes = end < start;
+
+    if (invalidTimes) {
       if (options.lock === 'end')
         start = bound(end - offset);
       else
@@ -343,7 +346,9 @@ VideoLinkShell.EditView = LinkShell.EditView.extend({
         {forceMinutes: true}));
     this.$el.find('#end').val(secondsToTimeString(end, {forceMinutes: true}));
     this.$el.find('#time').text(time);
-    this.$el.find('#slider').rangeslider({ max: max, values: [start, end] });
+
+    if (options.updateSlider || invalidTimes)
+      this.$el.find('#slider').rangeslider({values: [start, end]});
   },
 
   timeError: function() {

--- a/js/src/shells/videolink.shell.js
+++ b/js/src/shells/videolink.shell.js
@@ -239,7 +239,7 @@ VideoLinkShell.EditView = LinkShell.EditView.extend({
 
     // setup slider
     self = this;
-    this.$el.find('#slider').slider({
+    this.$el.find('#slider').rangeslider({
       min: 0,
       max: max,
       range: true,
@@ -342,7 +342,7 @@ VideoLinkShell.EditView = LinkShell.EditView.extend({
         {forceMinutes: true}));
     this.$el.find('#end').val(secondsToTimeString(end, {forceMinutes: true}));
     this.$el.find('#time').text(time);
-    this.$el.find('#slider').slider({ max: max, values: [start, end] });
+    this.$el.find('#slider').rangeslider({ max: max, values: [start, end] });
   },
 
   timeError: function() {

--- a/js/src/views/range_slider_widget.js
+++ b/js/src/views/range_slider_widget.js
@@ -40,13 +40,12 @@ $.widget("ui.rangeslider", $.ui.mouse, {
   },
 
   _create: function() {
-    var i, handleCount,
-        o = this.options,
-        existingHandles = this.element.find(".ui-slider-handle").
-            addClass("ui-state-default ui-corner-all"),
-        handle = "<div class='ui-slider-handle ui-state-default " +
-            "ui-corner-all'></div>",
-        handles = [];
+    var i, handleCount, o = this.options, existingHandles, handle, handles = [];
+
+    existingHandles = this.element.find(".ui-slider-handle").
+        addClass("ui-state-default ui-corner-all");
+    handle = "<div class='ui-slider-handle ui-state-default " +
+        "ui-corner-all'></div>";
 
     this._keySliding = false;
     this._mouseSliding = false;
@@ -124,8 +123,9 @@ $.widget("ui.rangeslider", $.ui.mouse, {
 
     this._on(this.handles, {
       keydown: function(event) {
-        var allowed, curVal, newVal, step,
-            index = $(event.target).data("ui-slider-handle-index");
+        var allowed, curVal, newVal, step, index;
+
+        index = $(event.target).data("ui-slider-handle-index");
 
         switch (event.keyCode) {
           case $.ui.keyCode.HOME:

--- a/js/src/views/range_slider_widget.js
+++ b/js/src/views/range_slider_widget.js
@@ -350,20 +350,34 @@ $.widget("ui.rangeslider", $.ui.mouse, {
     return this._trigger("start", event, uiHash);
   },
 
+  // call with `event, index, newVal` or `event, newValues`
   _slide: function(event, index, newVal) {
-    var newValues, allowed;
+    var newValues = this.values(), allowed;
 
-    if (newVal !== this.values(index)) {
-      newValues = this.values();
+    // assume call pattern based on index type
+    if (typeof(index) === "number") {
+      if (newValues[index] === newVal)
+        return;
       newValues[index] = newVal;
-      // A slide can be canceled by returning false from the slide callback
-      allowed = this._trigger("slide", event, {
-        handle: this.handles[index],
-        values: newValues.sort(function(a, b) { return a - b; }),
-      });
-      if (allowed !== false) {
-        this.values(index, newVal, true);
-      };
+
+    } else if ($.isArray(index)) {
+      if (newValues[0] = index[0] && newValues[1] === index[1])
+        return;
+      newValues[0] = index[0];
+      newValues[1] = index[1];
+      index = 0;
+
+    } else {
+      return false;
+    };
+
+    // A slide can be canceled by returning false from the slide callback
+    allowed = this._trigger("slide", event, {
+      handle: this.handles[index],
+      values: newValues.slice().sort(function(a, b) { return a - b; }),
+    });
+    if (allowed !== false) {
+      this.values(newValues);
     };
   },
 

--- a/js/src/views/range_slider_widget.js
+++ b/js/src/views/range_slider_widget.js
@@ -258,7 +258,7 @@ $.widget("ui.rangeslider", $.ui.mouse, {
     closestHandle.addClass("ui-state-active").focus();
 
     offset = closestHandle.offset();
-    mouseOverHandle = $(event.target).parents().andSelf().is(".ui-slider-handle");
+    mouseOverHandle = this.handles.hasClass("ui-state-hover");
     this._clickOffset = !mouseOverHandle ? { left: 0, top: 0 } : {
       left: event.pageX - offset.left - (closestHandle.outerWidth() / 2),
       top: event.pageY - offset.top -
@@ -268,7 +268,7 @@ $.widget("ui.rangeslider", $.ui.mouse, {
         (parseInt(closestHandle.css("marginTop"), 10) || 0),
     };
 
-    if (!this.handles.hasClass("ui-state-hover")) {
+    if (!mouseOverHandle) {
       this._slide(event, index, normValue);
     };
     this._animateOff = true;

--- a/js/src/views/range_slider_widget.js
+++ b/js/src/views/range_slider_widget.js
@@ -217,6 +217,30 @@ $.widget("ui.rangeslider", $.ui.mouse, {
     this._mouseDestroy();
   },
 
+  _inDOM: function() {
+    var element = this.element[0];
+
+    while (element = element.parentNode) {
+      if (element === document) {
+        return true;
+      };
+    };
+    return false;
+  },
+
+  _getDimensions: function() {
+    if (!this._inDOM())
+      return false;
+
+    this.elementSize = {
+      width: this.element.outerWidth(),
+      height: this.element.outerHeight(),
+    };
+    this.gotDimensions = true;
+
+    return true;
+  },
+
   _mouseCapture: function(event) {
     var position, normValue, distance, closestHandle, index, allowed, offset,
         mouseOverHandle, that = this, o = this.options;
@@ -225,10 +249,7 @@ $.widget("ui.rangeslider", $.ui.mouse, {
       return false;
     };
 
-    this.elementSize = {
-      width: this.element.outerWidth(),
-      height: this.element.outerHeight()
-    };
+    this.gotDimensions || this._getDimensions();
     this.elementOffset = this.element.offset();
 
     position = { x: event.pageX, y: event.pageY };

--- a/js/src/views/range_slider_widget.js
+++ b/js/src/views/range_slider_widget.js
@@ -613,10 +613,13 @@ $.widget("ui.rangeslider", $.ui.mouse, {
     position = this.orientation === "horizontal" ? "left" : "bottom";
     dimension = this.orientation === "horizontal" ? "width" : "height";
 
+    // element.outerWidth/Height isn't counting the border
+    borderWidth = parseInt(this.element.css('border-width'), 10);
+
     // rescale values by the the percent of the slider that they can fit in
     // without overflow, i.e. slider width/height minus one handle width/height
-    rangeScalar = (this.elementSize[dimension] - this.handleSize[dimension]) /
-        this.elementSize[dimension] * 100;
+    rangeScalar = (this.elementSize[dimension] + (2 * borderWidth) -
+        this.handleSize[dimension]) / this.elementSize[dimension] * 100;
 
     for (i = 0; i < 2; i++) {
       index = indices[i];

--- a/js/src/views/range_slider_widget.js
+++ b/js/src/views/range_slider_widget.js
@@ -319,13 +319,11 @@ $.widget("ui.rangeslider", $.ui.mouse, {
   },
 
   _mouseStop: function(event) {
-    var index = this._handleIndex === 1 ? 1 : 0;
-
     this.handles.removeClass("ui-state-active");
     this._mouseSliding = false;
 
-    this._stop(event, index);
-    this._change(event, index);
+    this._stop(event, this._handleIndex);
+    this._change(event, this._handleIndex);
 
     this._handleIndex = null;
     this._clickOffset = null;
@@ -374,7 +372,7 @@ $.widget("ui.rangeslider", $.ui.mouse, {
 
   _start: function(event, index) {
     var uiHash = {
-      handle: this.handles[index],
+      change: typeof(index) === "number" ? this.handles[index] : this.handles,
       values: this.orderedValues(),
     };
 
@@ -396,7 +394,6 @@ $.widget("ui.rangeslider", $.ui.mouse, {
         return;
       newValues[0] = index[0];
       newValues[1] = index[1];
-      index = 0;
 
     } else {
       return false;
@@ -404,7 +401,7 @@ $.widget("ui.rangeslider", $.ui.mouse, {
 
     // A slide can be canceled by returning false from the slide callback
     allowed = this._trigger("slide", event, {
-      handle: this.handles[index],
+      change: typeof(index) === "number" ? this.handles[index] : this.handles,
       values: newValues.slice().sort(function(a, b) { return a - b; }),
     });
     if (allowed !== false) {
@@ -414,7 +411,7 @@ $.widget("ui.rangeslider", $.ui.mouse, {
 
   _stop: function(event, index) {
     var uiHash = {
-      handle: this.handles[index],
+      change: typeof(index) === "number" ? this.handles[index] : this.handles,
       values: this.orderedValues(),
     };
 
@@ -424,12 +421,12 @@ $.widget("ui.rangeslider", $.ui.mouse, {
   _change: function(event, index) {
     if (!this._keySliding && !this._mouseSliding) {
       var uiHash = {
-        handle: this.handles[index],
+        change: typeof(index) === "number" ? this.handles[index] : this.handles,
         values: this.orderedValues(),
       };
 
       // store the last changed value index for reference when handles overlap
-      this._lastChangedValue = index;
+      this._lastChangedValue = typeof(index) === "number" ? index : 0;
 
       this._trigger("change", event, uiHash);
     };

--- a/js/src/views/range_slider_widget.js
+++ b/js/src/views/range_slider_widget.js
@@ -59,6 +59,7 @@ $.widget("ui.rangeslider", $.ui.mouse, {
         .addClass(
           "ui-slider" +
           " ui-slider-" + this.orientation +
+          " ui-range-slider" +
           " ui-widget" +
           " ui-widget-content" +
           " ui-corner-all"

--- a/js/src/views/range_slider_widget.js
+++ b/js/src/views/range_slider_widget.js
@@ -44,8 +44,8 @@ $.widget("ui.rangeslider", $.ui.mouse, {
         o = this.options,
         existingHandles = this.element.find(".ui-slider-handle").
             addClass("ui-state-default ui-corner-all"),
-        handle = "<a class='ui-slider-handle ui-state-default ui-corner-all' " +
-            "href='#'></a>",
+        handle = "<div class='ui-slider-handle ui-state-default " +
+            "ui-corner-all'></div>",
         handles = [];
 
     this._keySliding = false;
@@ -92,7 +92,7 @@ $.widget("ui.rangeslider", $.ui.mouse, {
 
     this.handle = this.handles.eq(0);
 
-    this.handles.add(this.range).filter("a")
+    this.handles.add(this.range).filter(".ui-slider-handle")
         .click(function(event) {
           event.preventDefault();
         })

--- a/js/src/views/range_slider_widget.js
+++ b/js/src/views/range_slider_widget.js
@@ -1,0 +1,672 @@
+/*!
+ * Range Slider
+ *
+ * jQuery UI widget for selecting a range. This is an optimized version of the
+ * range option for the slider widget built into jQuery UI.
+ *
+ * Adapted from jQuery UI Slider:
+ *   jQuery UI Slider @VERSION
+ *   http://jqueryui.com
+ *
+ *   Copyright 2012 jQuery Foundation and other contributors
+ *   Released under the MIT license.
+ *   http://jquery.org/license
+ *
+ *   http://api.jqueryui.com/slider/
+ *
+ *   Depends:
+ *  	jquery.ui.core.js
+ *  	jquery.ui.mouse.js
+ *  	jquery.ui.widget.js
+ */
+(function($, undefined) {
+
+// number of pages in a slider
+// (how many times can you page up/down to go through the whole range)
+var numPages = 5;
+
+$.widget("ui.rangeslider", $.ui.mouse, {
+  version: "@VERSION",
+  widgetEventPrefix: "rangeslide",
+
+  options: {
+    animate: false,
+    distance: 0,
+    max: 100,
+    min: 0,
+    orientation: "horizontal",
+    range: false,
+    step: 1,
+    value: 0,
+    values: null,
+  },
+
+  _create: function() {
+    var i, handleCount,
+        o = this.options,
+        existingHandles = this.element.find(".ui-slider-handle").
+            addClass("ui-state-default ui-corner-all"),
+        handle = "<a class='ui-slider-handle ui-state-default ui-corner-all' " +
+            "href='#'></a>",
+        handles = [];
+
+    this._keySliding = false;
+    this._mouseSliding = false;
+    this._animateOff = true;
+    this._handleIndex = null;
+    this._detectOrientation();
+    this._mouseInit();
+
+    this.element
+        .addClass(
+          "ui-slider" +
+          " ui-slider-" + this.orientation +
+          " ui-widget" +
+          " ui-widget-content" +
+          " ui-corner-all"
+        );
+
+    this.range = $([]);
+
+    if (o.range) {
+      if (o.range === true) {
+        if (!o.values) {
+          o.values = [this._valueMin(), this._valueMin()];
+        };
+        if (o.values.length && o.values.length !== 2) {
+          o.values = [o.values[0], o.values[0]];
+        };
+      };
+
+      this.range = $("<div></div>")
+          .appendTo(this.element)
+          .addClass(
+            "ui-slider-range" +
+            // note: this isn't the most fittingly semantic framework class
+            // for this element, but worked best visually with a variety of
+            // themes
+            " ui-widget-header" +
+            ((o.range === "min" || o.range === "max") ? " ui-slider-range-"
+                + o.range : "")
+          );
+    };
+
+    handleCount = (o.values && o.values.length) || 1;
+
+    for (i = existingHandles.length; i < handleCount; i++) {
+      handles.push(handle);
+    };
+
+    this.handles = existingHandles.add($(handles.join(""))
+        .appendTo(this.element));
+
+    this.handle = this.handles.eq(0);
+
+    this.handles.add(this.range).filter("a")
+        .click(function(event) {
+          event.preventDefault();
+        })
+        .mouseenter(function() {
+          if (!o.disabled) {
+            $(this).addClass("ui-state-hover");
+          };
+        })
+        .mouseleave(function() {
+          $(this).removeClass("ui-state-hover");
+        })
+        .focus(function() {
+          if (!o.disabled) {
+            $(".ui-slider .ui-state-focus").removeClass("ui-state-focus");
+            $(this).addClass("ui-state-focus");
+          } else {
+            $(this).blur();
+          };
+        })
+        .blur(function() {
+          $(this).removeClass("ui-state-focus");
+        });
+
+    this.handles.each(function(i) {
+      $(this).data("ui-slider-handle-index", i);
+    });
+
+    this._setOption("disabled", o.disabled);
+
+    this._on(this.handles, {
+      keydown: function(event) {
+        var allowed, curVal, newVal, step,
+            index = $(event.target).data("ui-slider-handle-index");
+
+        switch (event.keyCode) {
+          case $.ui.keyCode.HOME:
+          case $.ui.keyCode.END:
+          case $.ui.keyCode.PAGE_UP:
+          case $.ui.keyCode.PAGE_DOWN:
+          case $.ui.keyCode.UP:
+          case $.ui.keyCode.RIGHT:
+          case $.ui.keyCode.DOWN:
+          case $.ui.keyCode.LEFT:
+            event.preventDefault();
+            if (!this._keySliding) {
+              this._keySliding = true;
+              $(event.target).addClass("ui-state-active");
+              allowed = this._start(event, index);
+              if (allowed === false) {
+                return;
+              };
+            };
+            break;
+        };
+
+        step = this.options.step;
+        if (this.options.values && this.options.values.length) {
+          curVal = newVal = this.values(index);
+        } else {
+          curVal = newVal = this.value();
+        };
+
+        switch (event.keyCode) {
+          case $.ui.keyCode.HOME:
+            newVal = this._valueMin();
+            break;
+          case $.ui.keyCode.END:
+            newVal = this._valueMax();
+            break;
+          case $.ui.keyCode.PAGE_UP:
+            newVal = this._trimAlignValue(curVal + ((this._valueMax() -
+                this._valueMin()) / numPages));
+            break;
+          case $.ui.keyCode.PAGE_DOWN:
+            newVal = this._trimAlignValue(curVal - ((this._valueMax() -
+                this._valueMin()) / numPages));
+            break;
+          case $.ui.keyCode.UP:
+          case $.ui.keyCode.RIGHT:
+            if (curVal === this._valueMax()) {
+              return;
+            };
+            newVal = this._trimAlignValue(curVal + step);
+            break;
+          case $.ui.keyCode.DOWN:
+          case $.ui.keyCode.LEFT:
+            if (curVal === this._valueMin()) {
+              return;
+            };
+            newVal = this._trimAlignValue(curVal - step);
+            break;
+        };
+
+        this._slide(event, index, newVal);
+      },
+      keyup: function(event) {
+        var index = $(event.target).data("ui-slider-handle-index");
+
+        if (this._keySliding) {
+          this._keySliding = false;
+          this._stop(event, index);
+          this._change(event, index);
+          $(event.target).removeClass("ui-state-active");
+        };
+      },
+    });
+
+    this._refreshValue();
+
+    this._animateOff = false;
+  },
+
+  _destroy: function() {
+    this.handles.remove();
+    this.range.remove();
+
+    this.element.removeClass(
+      "ui-slider" +
+      " ui-slider-horizontal" +
+      " ui-slider-vertical" +
+      " ui-widget" +
+      " ui-widget-content" +
+      " ui-corner-all"
+    );
+
+    this._mouseDestroy();
+  },
+
+  _mouseCapture: function(event) {
+    var position, normValue, distance, closestHandle, index, allowed, offset,
+        mouseOverHandle, that = this, o = this.options;
+
+    if (o.disabled) {
+      return false;
+    };
+
+    this.elementSize = {
+      width: this.element.outerWidth(),
+      height: this.element.outerHeight()
+    };
+    this.elementOffset = this.element.offset();
+
+    position = { x: event.pageX, y: event.pageY };
+    normValue = this._normValueFromMouse(position);
+    distance = this._valueMax() - this._valueMin() + 1;
+    this.handles.each(function(i) {
+      var thisDistance = Math.abs(normValue - that.values(i));
+
+      if ((distance > thisDistance) ||
+        (distance === thisDistance &&
+          (i === that._lastChangedValue || that.values(i) === o.min))) {
+        distance = thisDistance;
+        closestHandle = $(this);
+        index = i;
+      };
+    });
+
+    allowed = this._start(event, index);
+    if (allowed === false) {
+      return false;
+    };
+    this._mouseSliding = true;
+
+    this._handleIndex = index;
+
+    closestHandle.addClass("ui-state-active").focus();
+
+    offset = closestHandle.offset();
+    mouseOverHandle = !$(event.target).parents().andSelf().is(".ui-slider-handle");
+    this._clickOffset = mouseOverHandle ? { left: 0, top: 0 } : {
+      left: event.pageX - offset.left - (closestHandle.width() / 2),
+      top: event.pageY - offset.top -
+        (closestHandle.height() / 2) -
+        (parseInt(closestHandle.css("borderTopWidth"), 10) || 0) -
+        (parseInt(closestHandle.css("borderBottomWidth"), 10) || 0) +
+        (parseInt(closestHandle.css("marginTop"), 10) || 0),
+    };
+
+    if (!this.handles.hasClass("ui-state-hover")) {
+      this._slide(event, index, normValue);
+    };
+    this._animateOff = true;
+    return true;
+  },
+
+  _mouseStart: function() {
+    return true;
+  },
+
+  _mouseDrag: function(event) {
+    var position, normValue;
+    
+    position = { x: event.pageX, y: event.pageY };
+    normValue = this._normValueFromMouse(position);
+
+    this._slide(event, this._handleIndex, normValue);
+
+    return false;
+  },
+
+  _mouseStop: function(event) {
+    this.handles.removeClass("ui-state-active");
+    this._mouseSliding = false;
+
+    this._stop(event, this._handleIndex);
+    this._change(event, this._handleIndex);
+
+    this._handleIndex = null;
+    this._clickOffset = null;
+    this._animateOff = false;
+
+    return false;
+  },
+
+  _detectOrientation: function() {
+    if (this.options.orientation === "vertical")
+      this.orientation = "vertical";
+    else
+      this.orientation = "horizontal";
+  },
+
+  _normValueFromMouse: function(position) {
+    var pixelTotal, pixelMouse, percentMouse, valueTotal, valueMouse;
+
+    if (this.orientation === "horizontal") {
+      pixelTotal = this.elementSize.width;
+      pixelMouse = position.x - this.elementOffset.left - (this._clickOffset ?
+          this._clickOffset.left : 0);
+    } else {
+      pixelTotal = this.elementSize.height;
+      pixelMouse = position.y - this.elementOffset.top - (this._clickOffset ?
+          this._clickOffset.top : 0);
+    };
+
+    percentMouse = (pixelMouse / pixelTotal);
+    if (percentMouse > 1) {
+      percentMouse = 1;
+    };
+    if (percentMouse < 0) {
+      percentMouse = 0;
+    };
+    if (this.orientation === "vertical") {
+      percentMouse = 1 - percentMouse;
+    };
+
+    valueTotal = this._valueMax() - this._valueMin();
+    valueMouse = this._valueMin() + percentMouse * valueTotal;
+
+    return this._trimAlignValue(valueMouse);
+  },
+
+  _start: function(event, index) {
+    var uiHash = {
+      handle: this.handles[index],
+      value: this.value()
+    };
+    if (this.options.values && this.options.values.length) {
+      uiHash.value = this.values(index);
+      uiHash.values = this.values();
+    };
+    return this._trigger("start", event, uiHash);
+  },
+
+  _slide: function(event, index, newVal) {
+    var otherVal, isRange, newValues, allowed;
+
+    if (this.options.values && this.options.values.length) {
+      otherVal = this.values(index ? 0 : 1);
+
+      isRange = this.options.values.length === 2 && this.options.range === true;
+      valuesCrossed = index === 0 && newVal > otherVal ||
+          index === 1 && newVal < otherVal;
+
+      if (isRange && valuesCrossed)
+        newVal = otherVal;
+
+      if (newVal !== this.values(index)) {
+        newValues = this.values();
+        newValues[index] = newVal;
+        // A slide can be canceled by returning false from the slide callback
+        allowed = this._trigger("slide", event, {
+          handle: this.handles[index],
+          value: newVal,
+          values: newValues
+        });
+        if (allowed !== false) {
+          this.values(index, newVal, true);
+        };
+      };
+    } else {
+      if (newVal !== this.value()) {
+        // A slide can be canceled by returning false from the slide callback
+        allowed = this._trigger("slide", event, {
+          handle: this.handles[index],
+          value: newVal
+        });
+        if (allowed !== false) {
+          this.value(newVal);
+        };
+      };
+    };
+  },
+
+  _stop: function(event, index) {
+    var uiHash = {
+      handle: this.handles[index],
+      value: this.value()
+    };
+    if (this.options.values && this.options.values.length) {
+      uiHash.value = this.values(index);
+      uiHash.values = this.values();
+    };
+
+    this._trigger("stop", event, uiHash);
+  },
+
+  _change: function(event, index) {
+    if (!this._keySliding && !this._mouseSliding) {
+      var uiHash = {
+        handle: this.handles[index],
+        value: this.value()
+      };
+      if (this.options.values && this.options.values.length) {
+        uiHash.value = this.values(index);
+        uiHash.values = this.values();
+      };
+
+      // store the last changed value index for reference when handles overlap
+      this._lastChangedValue = index;
+
+      this._trigger("change", event, uiHash);
+    };
+  },
+
+  value: function(newValue) {
+    if (arguments.length) {
+      this.options.value = this._trimAlignValue(newValue);
+      this._refreshValue();
+      this._change(null, 0);
+      return;
+    };
+
+    return this._value();
+  },
+
+  values: function(index, newValue) {
+    var vals, newValues, i;
+
+    if (arguments.length > 1) {
+      this.options.values[index] = this._trimAlignValue(newValue);
+      this._refreshValue();
+      this._change(null, index);
+      return;
+    };
+
+    if (arguments.length) {
+      if ($.isArray(arguments[0])) {
+        vals = this.options.values;
+        newValues = arguments[0];
+        for (i = 0; i < vals.length; i += 1) {
+          vals[i] = this._trimAlignValue(newValues[i]);
+          this._change(null, i);
+        };
+        this._refreshValue();
+      } else {
+        if (this.options.values && this.options.values.length) {
+          return this._values(index);
+        } else {
+          return this.value();
+        };
+      };
+    } else {
+      return this._values();
+    };
+  },
+
+  _setOption: function(key, value) {
+    var i, valsLength = 0;
+
+    if ($.isArray(this.options.values)) {
+      valsLength = this.options.values.length;
+    };
+
+    $.Widget.prototype._setOption.apply(this, arguments);
+
+    switch (key) {
+      case "disabled":
+        if (value) {
+          this.handles.filter(".ui-state-focus").blur();
+          this.handles.removeClass("ui-state-hover");
+          this.handles.prop("disabled", true);
+        } else {
+          this.handles.prop("disabled", false);
+        };
+        break;
+      case "orientation":
+        this._detectOrientation();
+        this.element
+          .removeClass("ui-slider-horizontal ui-slider-vertical")
+          .addClass("ui-slider-" + this.orientation);
+        this._refreshValue();
+        break;
+      case "value":
+        this._animateOff = true;
+        this._refreshValue();
+        this._change(null, 0);
+        this._animateOff = false;
+        break;
+      case "values":
+        this._animateOff = true;
+        this._refreshValue();
+        for (i = 0; i < valsLength; i += 1) {
+          this._change(null, i);
+        };
+        this._animateOff = false;
+        break;
+      case "min":
+      case "max":
+        this._animateOff = true;
+        this._refreshValue();
+        this._animateOff = false;
+        break;
+    };
+  },
+
+  // internal value getter
+  // _value() returns value trimmed by min and max, aligned by step
+  _value: function() {
+    var val = this.options.value;
+    val = this._trimAlignValue(val);
+
+    return val;
+  },
+
+  // internal values getter
+  // _values() returns array of values trimmed by min and max, aligned by step
+  // _values(index) returns single value trimmed by min and max, aligned by step
+  _values: function(index) {
+    var val, vals, i;
+
+    if (arguments.length) {
+      val = this.options.values[index];
+      val = this._trimAlignValue(val);
+
+      return val;
+    } else {
+      // .slice() creates a copy of the array
+      // this copy gets trimmed by min and max and then returned
+      vals = this.options.values.slice();
+      for (i = 0; i < vals.length; i+= 1) {
+        vals[i] = this._trimAlignValue(vals[i]);
+      };
+
+      return vals;
+    };
+  },
+
+  // returns the step-aligned value that val is closest to, between (inclusive) min and max
+  _trimAlignValue: function(val) {
+    var step, valModStep, alignValue;
+
+    if (val <= this._valueMin()) {
+      return this._valueMin();
+    };
+    if (val >= this._valueMax()) {
+      return this._valueMax();
+    };
+
+    step = (this.options.step > 0) ? this.options.step : 1;
+    valModStep = (val - this._valueMin()) % step;
+    alignValue = val - valModStep;
+
+    if (Math.abs(valModStep) * 2 >= step) {
+      alignValue += (valModStep > 0) ? step : (-step);
+    };
+
+    // Since JavaScript has problems with large floats, round
+    // the final value to 5 digits after the decimal point (see #4124)
+    return parseFloat(alignValue.toFixed(5));
+  },
+
+  _valueMin: function() {
+    return this.options.min;
+  },
+
+  _valueMax: function() {
+    return this.options.max;
+  },
+
+  _refreshValue: function() {
+    var lastValPercent, valPercent, value, valueMin, valueMax,
+        oRange = this.options.range, o = this.options, that = this,
+        animate = (!this._animateOff) ? o.animate : false, _set = {};
+
+    if (this.options.values && this.options.values.length) {
+      this.handles.each(function(i) {
+        valPercent = (that.values(i) - that._valueMin()) /
+            (that._valueMax() - that._valueMin()) * 100;
+        _set[that.orientation === "horizontal" ? "left" : "bottom"] =
+            valPercent + "%";
+        $(this).stop(1, 1)[animate ? "animate" : "css"](_set,
+            o.animate);
+        if (that.options.range === true) {
+          if (that.orientation === "horizontal") {
+            if (i === 0) {
+              that.range.stop(1, 1)[animate ? "animate" : "css"](
+                  { left: valPercent + "%" },
+                  o.animate);
+            };
+            if (i === 1) {
+              that.range[animate ? "animate" : "css"](
+                  { width: (valPercent - lastValPercent) + "%" },
+                  { queue: false, duration: o.animate });
+            };
+          } else {
+            if (i === 0) {
+              that.range.stop(1, 1)[animate ? "animate" : "css"](
+                  { bottom: (valPercent) + "%" },
+                  o.animate);
+            };
+            if (i === 1) {
+              that.range[animate ? "animate" : "css"](
+                  { height: (valPercent - lastValPercent) + "%" },
+                  { queue: false, duration: o.animate });
+            };
+          };
+        };
+        lastValPercent = valPercent;
+      });
+    } else {
+      value = this.value();
+      valueMin = this._valueMin();
+      valueMax = this._valueMax();
+      valPercent = (valueMax !== valueMin) ?
+          (value - valueMin) / (valueMax - valueMin) * 100 : 0;
+      _set[this.orientation === "horizontal" ? "left" : "bottom"] =
+          valPercent + "%";
+      this.handle.stop(1, 1)[animate ? "animate" : "css"](
+          _set,
+          o.animate);
+
+      if (oRange === "min" && this.orientation === "horizontal") {
+        this.range.stop(1, 1)[animate ? "animate" : "css"](
+          { width: valPercent + "%" },
+          o.animate);
+      };
+      if (oRange === "max" && this.orientation === "horizontal") {
+        this.range[animate ? "animate" : "css"](
+            { width: (100 - valPercent) + "%" },
+            { queue: false, duration: o.animate });
+      };
+      if (oRange === "min" && this.orientation === "vertical") {
+        this.range.stop(1, 1)[animate ? "animate" : "css"](
+            { height: valPercent + "%" },
+            o.animate);
+      };
+      if (oRange === "max" && this.orientation === "vertical") {
+        this.range[animate ? "animate" : "css"](
+            { height: (100 - valPercent) + "%" },
+            { queue: false, duration: o.animate });
+      };
+    };
+  },
+
+});
+
+}(jQuery));

--- a/js/src/views/range_slider_widget.js
+++ b/js/src/views/range_slider_widget.js
@@ -258,11 +258,11 @@ $.widget("ui.rangeslider", $.ui.mouse, {
     closestHandle.addClass("ui-state-active").focus();
 
     offset = closestHandle.offset();
-    mouseOverHandle = !$(event.target).parents().andSelf().is(".ui-slider-handle");
-    this._clickOffset = mouseOverHandle ? { left: 0, top: 0 } : {
-      left: event.pageX - offset.left - (closestHandle.width() / 2),
+    mouseOverHandle = $(event.target).parents().andSelf().is(".ui-slider-handle");
+    this._clickOffset = !mouseOverHandle ? { left: 0, top: 0 } : {
+      left: event.pageX - offset.left - (closestHandle.outerWidth() / 2),
       top: event.pageY - offset.top -
-        (closestHandle.height() / 2) -
+        (closestHandle.outerHeight() / 2) -
         (parseInt(closestHandle.css("borderTopWidth"), 10) || 0) -
         (parseInt(closestHandle.css("borderBottomWidth"), 10) || 0) +
         (parseInt(closestHandle.css("marginTop"), 10) || 0),

--- a/player.html
+++ b/player.html
@@ -30,7 +30,7 @@
 <script src="/js/libs/backbone/backbone-min.js"></script>
 <script src="/js/libs/bootstrap/js/bootstrap.min.js"></script>
 <script src="/js/libs/components/editabletext.js"></script>
-<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.21/jquery-ui.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.9.1/jquery-ui.min.js"></script>
 
 <script src="/js/src/acorn.js"></script>
 

--- a/player.html
+++ b/player.html
@@ -37,6 +37,8 @@
 <!-- common-js submodule -->
 <script src="/js/src/common/remote_resource.js"></script>
 
+<script src='/js/src/views/range_slider_widget.js'></script>
+
 <script src="/js/src/shells/shell.js"></script>
 <script src="/js/src/shells/link.shell.js"></script>
 <script src="/js/src/shells/videolink.shell.js"></script>


### PR DESCRIPTION
Builds a `rangeslider` jQuery UI widget based off of the built-in jQuery UI `slider` widget and replaces the built-in widget in `VideoLinkShell` edit views.

The `rangeslider` widget:
- allows handles to cross over one another
- allows the entire selected bar to be shifted side-to-side as a unit
- will likely facilitate a solution to slider handles sticking out past the edges of the slider beam
