### PR TITLE
Looping

### DIFF
--- a/css/acorn-player.css
+++ b/css/acorn-player.css
@@ -458,21 +458,21 @@ h1, h2, h3, h4, h5, h6 {
   margin-right: 5px;
   text-align: center;
 }
-#acorn-player > #edit .acorn-shell-edit .thumbnailside div.loop.hidden {
+#acorn-player > #edit .acorn-shell-edit .thumbnailside div.loops.hidden {
   display: none;
 }
 
-#acorn-player > #edit .acorn-shell-edit .thumbnailside div.loop-none span,
-#acorn-player > #edit .acorn-shell-edit .thumbnailside div.loop-infinity span,
-#acorn-player > #edit .acorn-shell-edit .thumbnailside div.loop-n input {
+#acorn-player > #edit .acorn-shell-edit .thumbnailside div.one-loops span,
+#acorn-player > #edit .acorn-shell-edit .thumbnailside div.infinity-loops span,
+#acorn-player > #edit .acorn-shell-edit .thumbnailside div.n-loops input {
   width: 30px;
   margin-left: -4px;
   margin-right: 5px;
   text-align: center;
 }
 
-#acorn-player > #edit .acorn-shell-edit .thumbnailside div.loop-none span,
-#acorn-player > #edit .acorn-shell-edit .thumbnailside div.loop-infinity span {
+#acorn-player > #edit .acorn-shell-edit .thumbnailside div.one-loops span,
+#acorn-player > #edit .acorn-shell-edit .thumbnailside div.infinity-loops span {
   background-color: #F4F4F4;
 }
 

--- a/js/src/shells/videolink.shell.js
+++ b/js/src/shells/videolink.shell.js
@@ -148,15 +148,15 @@ VideoLinkShell.ContentView = LinkShell.ContentView.extend({
     }
 
     // if current playback is after the end time, pause or loop. when looping,
-    // avoid decrementing the loop count multiple times before successfully
-    // restarting
+    // set `restarting` flag to avoid decrementing the loop count multiple
+    // times before the restart has completed
     if (playing && now >= end) {
       if (this.restarting)
         return;
 
       if (_.isNumber(loops)) {
         this.looped = this.looped || 0;
-        this.looped ++;
+        this.looped++;
       };
 
       if (loops === 'infinity' || (_.isNumber(loops) && loops > this.looped)) {

--- a/js/src/shells/videolink.shell.js
+++ b/js/src/shells/videolink.shell.js
@@ -134,8 +134,7 @@ VideoLinkShell.ContentView = LinkShell.ContentView.extend({
 
   onPlaybackTick: function() {
     // get shell options
-    // TODO: handle looping correctly
-    var loops = this.shell.data.loops || false;
+    var loops = this.shell.data.loops;
     var end = this.shell.data.time_end || this.totalTime();
     var start = this.shell.data.time_start || 0;
 
@@ -148,15 +147,30 @@ VideoLinkShell.ContentView = LinkShell.ContentView.extend({
       this.seek(start);
     }
 
-    // if current playback is after the end time, pause (or loop)
+    // if current playback is after the end time, pause or loop. when looping,
+    // avoid decrementing the loop count multiple times before successfully
+    // restarting
     if (playing && now >= end) {
-      if (loops) {
+      if (this.restarting)
+        return;
+
+      if (_.isNumber(loops)) {
+        this.looped = this.looped || 0;
+        this.looped ++;
+      };
+
+      if (loops === 'infinity' || (_.isNumber(loops) && loops > this.looped)) {
         this.seek(start);
+        this.restarting = true;
+
       } else {
         this.stop();
         this.trigger('playback:ended');
-      }
-    }
+      };
+
+    } else {
+      this.restarting = false;
+    };
   },
 
 });


### PR DESCRIPTION
redesigns `loop` widget to `loops` widget, thereby reflecting a videos total plays as opposed to total times looping after initial play. implements proper looping.

![](http://static.benet.ai/skitch_tenedor/acorn_-_multimedia_wrapper-20121128-042453.jpg)

I'm not too happy with this design for the loops button - @ali01 and I discussed it and haven't come to a great solution, though toggles and dropdowns seem worth consideration.
