### PR TITLE
Text polish

### DIFF
--- a/coffee/src/shells/videolink.shell.coffee
+++ b/coffee/src/shells/videolink.shell.coffee
@@ -43,7 +43,7 @@ class VideoLinkShell.Model extends LinkShell.Model
       end = acorn.util.Time.secondsToTimestring @timeEnd()
       clipping = " from #{start} to #{end}"
 
-    "Video \"#{@link()}\"#{clipping ? ''}."
+    "Remix of video \"#{@link()}\"#{clipping ? ''}."
 
 
   # duration of one video loop given current splicing

--- a/coffee/src/shells/vimeo.shell.coffee
+++ b/coffee/src/shells/vimeo.shell.coffee
@@ -36,7 +36,8 @@ class VimeoShell.Model extends VideoLinkShell.Model
       end = acorn.util.Time.secondsToTimestring @timeEnd()
       clipping = " from #{start} to #{end}"
 
-    "Vimeo video \"#{@_fetchedDefaults?.title ? @link()}\"#{clipping ? ''}."
+    "Remix of Vimeo video \"#{@_fetchedDefaults?.title ?
+        @link()}\"#{clipping ? ''}."
 
 
   metaDataUrl: =>

--- a/coffee/src/shells/youtube.shell.coffee
+++ b/coffee/src/shells/youtube.shell.coffee
@@ -42,7 +42,8 @@ class YouTubeShell.Model extends VideoLinkShell.Model
       end = acorn.util.Time.secondsToTimestring @timeEnd()
       clipping = " from #{start} to #{end}"
 
-    "YouTube video \"#{@_fetchedDefaults?.title ? @link()}\"#{clipping ? ''}."
+    "Remix of YouTube video \"#{@_fetchedDefaults?.title ?
+        @link()}\"#{clipping ? ''}."
 
 
   metaDataUrl: =>

--- a/coffee/src/views/remixer_view.coffee
+++ b/coffee/src/views/remixer_view.coffee
@@ -172,13 +172,16 @@ class acorn.player.RemixerView extends athena.lib.View
     @$linkContainer.children('#link').remove()
 
     if shell.RemixView.activeLinkInput
+      placeholder = 'enter link to media (e.g. a youtube video, image, or pdf)'
       @$linkContainer.removeClass 'input-prepend'
-      @$linkContainer.prepend '<input id="link" type="text" placeholder="enter link"/>'
+      @$linkContainer.prepend "<input id='link' type='text'
+          placeholder='#{placeholder}'/>"
       @$linkContainer.children('input#link').val @model.link?()
 
     else
       @$linkContainer.addClass 'input-prepend'
-      @$linkContainer.prepend '<span id="link" class="add-on uneditable-input"></span>'
+      @$linkContainer.prepend '<span id="link" class="add-on uneditable-input">
+          </span>'
       linkSpanText = "#{shell.title} - #{shell.description}"
       @$linkContainer.children('span#link').text linkSpanText
 

--- a/coffee/test/shells/videolink.shell.spec.coffee
+++ b/coffee/test/shells/videolink.shell.spec.coffee
@@ -88,15 +88,16 @@ describe 'acorn.shells.VideoLinkShell', ->
 
         it 'should return a message about video source and clipping', ->
           model = new Model modelOptions()
-          expect(model._defaultDescription()).toBe "Video \"#{videoLink}\" " +
-              "from 00:33 to 02:25."
+          expect(model._defaultDescription()).toBe "Remix of video " +
+              "\"#{videoLink}\" from 00:33 to 02:25."
 
         it 'should return a message about video source only when lacking valid
             start/end times', ->
           options = modelOptions()
           options.timeStart = NaN
           model = new Model options
-          expect(model._defaultDescription()).toBe "Video \"#{videoLink}\"."
+          expect(model._defaultDescription()).toBe "Remix of video " +
+              "\"#{videoLink}\"."
 
 
     describe 'VideoLinkShell.MediaView', ->

--- a/coffee/test/shells/vimeo.shell.spec.coffee
+++ b/coffee/test/shells/vimeo.shell.spec.coffee
@@ -102,12 +102,12 @@ describe 'acorn.shells.VimeoShell', ->
           model = new Model modelOptions()
 
           model._fetchedDefaults = title: undefined
-          expect(model._defaultDescription()).toBe "Vimeo video \"#{videoLink}\"" +
-              " from 00:33 to 02:25."
+          expect(model._defaultDescription()).toBe "Remix of Vimeo video " +
+              "\"#{videoLink}\" from 00:33 to 02:25."
 
           model._fetchedDefaults = title: 'FakeVimeoTitle'
-          expect(model._defaultDescription()).toBe "Vimeo video \"FakeVimeo" +
-              "Title\" from 00:33 to 02:25."
+          expect(model._defaultDescription()).toBe "Remix of Vimeo video " +
+              "\"FakeVimeoTitle\" from 00:33 to 02:25."
 
         it 'should return a message about video title only when lacking valid
             start/end times', ->
@@ -116,12 +116,12 @@ describe 'acorn.shells.VimeoShell', ->
           model = new Model options
 
           model._fetchedDefaults = title: undefined
-          expect(model._defaultDescription()).toBe "Vimeo video " +
+          expect(model._defaultDescription()).toBe "Remix of Vimeo video " +
               "\"#{videoLink}\"."
 
           model._fetchedDefaults = title: 'FakeVimeoTitle'
-          expect(model._defaultDescription()).toBe "Vimeo video \"FakeVimeo" +
-              "Title\"."
+          expect(model._defaultDescription()).toBe "Remix of Vimeo video " +
+              "\"FakeVimeoTitle\"."
 
 
     describe 'VimeoShell.PlayerView', ->

--- a/coffee/test/shells/youtube.shell.spec.coffee
+++ b/coffee/test/shells/youtube.shell.spec.coffee
@@ -107,11 +107,11 @@ describe 'acorn.shells.YouTubeShell', ->
           model = new Model modelOptions()
 
           model._fetchedDefaults = title: undefined
-          expect(model._defaultDescription()).toBe "YouTube video " +
+          expect(model._defaultDescription()).toBe "Remix of YouTube video " +
               "\"#{videoLink}\" from 00:33 to 02:25."
 
           model._fetchedDefaults = title: 'FakeYouTubeTitle'
-          expect(model._defaultDescription()).toBe "YouTube video " +
+          expect(model._defaultDescription()).toBe "Remix of YouTube video " +
               "\"FakeYouTubeTitle\" from 00:33 to 02:25."
 
         it 'should return a message about video title only when lacking valid
@@ -121,11 +121,11 @@ describe 'acorn.shells.YouTubeShell', ->
           model = new Model options
 
           model._fetchedDefaults = title: undefined
-          expect(model._defaultDescription()).toBe "YouTube video " +
+          expect(model._defaultDescription()).toBe "Remix of YouTube video " +
               "\"#{videoLink}\"."
 
           model._fetchedDefaults = title: 'FakeYouTubeTitle'
-          expect(model._defaultDescription()).toBe "YouTube video " +
+          expect(model._defaultDescription()).toBe "Remix of YouTube video " +
               "\"FakeYouTubeTitle\"."
 
 


### PR DESCRIPTION
in remixer:
- prepend video descriptions with 'Remix of'
- change link field placeholder to read "enter link to media (e.g. a youtube video, image, or pdf)"
