### PR TITLE
Updated README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ See it at [http://localhost:8000/static/player.html](http://localhost:8000/stati
 
 Note: Node v.0.10.4 gives errors when used with our version of grunt. The
 highest supported version of Node is 0.8.16. Instructions on installing older
-versions of Node via ``brew`` are available [here](http://stackoverflow.com/questions/3987683/homebrew-install-specific-version-of-formula).
+versions of Node via ``brew`` are available
+[here](http://stackoverflow.com/a/9832084).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,20 @@ Download the source:
 
     git clone git@github.com:athenalabs/acorn-player.git
 
-Build it
+Initialize the Closure submodule:
+
+    git submodule update
+    git submodule init
+
+Create the necessary symlinks:
+
+    ln -s Gruntfile.coffee Grunt.js
+    ln -s <path to compiler.jar> lib/closure/
+
+Build it:
 
     npm install
-    grunt compile
+    node_modules/grunt-exec/bin/grunt-exec compile
 
 Run a server with the following command:
 
@@ -62,7 +72,11 @@ Run a server with the following command:
 
 See it at [http://localhost:8000/static/player.html](http://localhost:8000/static/player.html)
 
-
+Note: Node v.0.10.4 gives errors when used with our version of grunt. The
+highest supported version of Node we currently support is 0.8.16. To see
+instructions on installing older versions of Node via ``brew'', see 
+[this
+post](http://stackoverflow.com/questions/3987683/homebrew-install-specific-version-of-formula).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Run a server with the following command:
 
 See it at [http://localhost:8000/static/player.html](http://localhost:8000/static/player.html)
 
-Note: Node v.0.10.4 gives errors when used with our version of grunt. The
+Note: Node v0.10.4 gives errors when used with our version of Grunt. The
 highest supported version of Node is 0.8.16. Instructions on installing older
 versions of Node via ``brew`` are available
 [here](http://stackoverflow.com/a/9832084).

--- a/README.md
+++ b/README.md
@@ -73,10 +73,8 @@ Run a server with the following command:
 See it at [http://localhost:8000/static/player.html](http://localhost:8000/static/player.html)
 
 Note: Node v.0.10.4 gives errors when used with our version of grunt. The
-highest supported version of Node we currently support is 0.8.16. To see
-instructions on installing older versions of Node via ``brew'', see 
-[this
-post](http://stackoverflow.com/questions/3987683/homebrew-install-specific-version-of-formula).
+highest supported version of Node is 0.8.16. Instructions on installing older
+versions of Node via ``brew`` are available [here](http://stackoverflow.com/questions/3987683/homebrew-install-specific-version-of-formula).
 
 ## Usage
 


### PR DESCRIPTION
The installation instructions now reflect the exact process needed to set up `acorn-player` from a fresh install. The changes include:
1. Specifying that only Node v0.8.16 has been tested to work and v0.10.4 is confirmed unsupported.
2. Including instructions to symlink in Closure.jar and Grunt.js
3. How to initialize closure git submodule
4. How to run local version of Grunt because `npm install` installs Grunt into node_modules

I just re-installed acorn-player using the above changes and everything works!
