### PR TITLE
YouTube Shell/Remixer Queries URL for default start/end times

### DIFF
--- a/coffee/src/shells/videolink.shell.coffee
+++ b/coffee/src/shells/videolink.shell.coffee
@@ -291,6 +291,12 @@ class VideoLinkShell.RemixView extends LinkShell.RemixView
   _setTimeInputMax: =>
     @timeRangeView.setMax @model.timeTotal()
 
+  _setClipRange: =>
+    @timeRangeView.values {
+      start: @model.timeStart()
+      end: @model.timeEnd()
+    }
+
 
   onChangeTimes: (changed) =>
     changes = {}

--- a/coffee/src/util/util.coffee
+++ b/coffee/src/util/util.coffee
@@ -287,7 +287,7 @@ util.fetchParameters = (url, params) ->
   search = anchor.search.substring(1)
   search = '{"' + search.replace(/&/g, '","').replace(/\=/g, '":"') + '"}'
   
-  parameters = if search is "" then {} else JSON.parse search, (key, value) -> 
+  parameters = JSON.parse search, (key, value) -> 
       if key is "" then value else decodeURIComponent value
   
   _.pick parameters, params

--- a/coffee/src/util/util.coffee
+++ b/coffee/src/util/util.coffee
@@ -290,8 +290,6 @@ util.fetchParameters = (url, params) ->
   parameters = if search is "" then {} else JSON.parse search, (key, value) -> 
       if key is "" then value else decodeURIComponent value
   
-
-  console.log(parameters)
   _.pick parameters, params
   
 

--- a/coffee/src/util/util.coffee
+++ b/coffee/src/util/util.coffee
@@ -274,7 +274,26 @@ util.parseUrl = (url) ->
 
   result
 
+# function takes a URL and an array of parameters
+# returns JSON object with matching parameters and values, if any
+# otherwise, returns empty object
+# http://stackoverflow.com/a/8649003
+util.fetchParameters = (url, params) ->
+  url = $.trim url
+  url = "http://#{url}" unless /^([a-z0-9]+:)?\/\//i.test url  
+  anchor = document.createElement 'a'
+  anchor.href = url
 
+  search = anchor.search.substring(1)
+  search = '{"' + search.replace(/&/g, '","').replace(/\=/g, '":"') + '"}'
+  
+  parameters = if search is "" then {} else JSON.parse search, (key, value) -> 
+      if key is "" then value else decodeURIComponent value
+  
+
+  console.log(parameters)
+  _.pick parameters, params
+  
 
 # track mouse location at all times
 util.mouseLocationTracker = (->

--- a/coffee/src/views/index.coffee
+++ b/coffee/src/views/index.coffee
@@ -21,7 +21,6 @@
 `import "shell_editor_view"`
 `import "shell_options_view"`
 `import "shell_selector_view"`
-`import "slider_handle_view"`
 `import "sliding_bar_view"`
 `import "sliding_object_view"`
 `import "sources_view"`


### PR DESCRIPTION
Resolves issue #122 . The YouTube Remixer now sets clip selection according to the URL, if available. Supported time formats:
- `t=<n>`
- `t=<n1>m<n2>s`
- ``start=<n>`
- `start=<n1>m<n2>s`
- `end=<n>`
- ``end=<n1>m<n2>s`

Currently, this functionality is limited to YouTube videos, but `initializeDefaultClip` can be moved up to LinkShell in general in order to handle other URL parameters (if relevant).

This pull request also introduces a new utility function `acorn.util.fetchParameters`. This function takes a URL and an array of parameters and returns an object with the parameters and their values, if available. If the parameters are not present, then they are not in the object. In the case that no parameters are supplied in the URL, the empty object is returned.
