### PR TITLE
remix: remixer view encodes urls for linkshell

### DIFF
--- a/coffee/src/views/remixer_view.coffee
+++ b/coffee/src/views/remixer_view.coffee
@@ -282,6 +282,7 @@ class acorn.player.RemixerView extends athena.lib.View
     @alert() # hide
     link = @$linkContainer.children('input#link').val().trim()
     link = acorn.util.urlFix link
+    encodedLink = encodeURI(link)
 
     # idempotent
     if link is @model.link?()
@@ -296,8 +297,8 @@ class acorn.player.RemixerView extends athena.lib.View
       @model.link link
       @renderRemixSubview()
 
-    else if acorn.util.isUrl link
-      shell = LinkShell.Model.withLink link
+    else if acorn.util.isUrl encodedLink
+      shell = LinkShell.Model.withLink encodedLink
 
       unless @shellIsValid shell
         console.log 'invalid shell'


### PR DESCRIPTION
Acorn will only work with encoded URLs. This will avoid any possible issues with string escaping in URLs, and will fix an error where the Chrome RegExp implementation did not gracefully handle unescaped quotes.  

The stored link will continue to be unescaped, preserving the user's input.
